### PR TITLE
swift-format

### DIFF
--- a/.swift-format.json
+++ b/.swift-format.json
@@ -1,0 +1,53 @@
+{
+  "blankLineBetweenMembers" : {
+    "ignoreSingleLineProperties" : true
+  },
+  "indentation" : {
+    "spaces" : 4
+  },
+  "indentConditionalCompilationBlocks" : true,
+  "lineBreakBeforeControlFlowKeywords" : false,
+  "lineBreakBeforeEachArgument" : false,
+  "lineLength" : 100,
+  "maximumBlankLines" : 1,
+  "respectsExistingLineBreaks" : true,
+  "rules" : {
+    "AllPublicDeclarationsHaveDocumentation" : true,
+    "AlwaysUseLowerCamelCase" : true,
+    "AmbiguousTrailingClosureOverload" : true,
+    "BeginDocumentationCommentWithOneLineSummary" : true,
+    "BlankLineBetweenMembers" : true,
+    "CaseIndentLevelEqualsSwitch" : true,
+    "DoNotUseSemicolons" : true,
+    "DontRepeatTypeInStaticProperties" : true,
+    "FullyIndirectEnum" : true,
+    "GroupNumericLiterals" : true,
+    "IdentifiersMustBeASCII" : true,
+    "MultiLineTrailingCommas" : true,
+    "NeverForceUnwrap" : true,
+    "NeverUseForceTry" : true,
+    "NeverUseImplicitlyUnwrappedOptionals" : true,
+    "NoAccessLevelOnExtensionDeclaration" : true,
+    "NoBlockComments" : true,
+    "NoCasesWithOnlyFallthrough" : true,
+    "NoEmptyTrailingClosureParentheses" : true,
+    "NoLabelsInCasePatterns" : true,
+    "NoLeadingUnderscores" : true,
+    "NoParensAroundConditions" : true,
+    "NoVoidReturnOnFunctionSignature" : true,
+    "OneCasePerLine" : true,
+    "OneVariableDeclarationPerLine" : true,
+    "OnlyOneTrailingClosureArgument" : true,
+    "OrderedImports" : true,
+    "ReturnVoidInsteadOfEmptyTuple" : true,
+    "UseEnumForNamespacing" : true,
+    "UseLetInEveryBoundCaseVariable" : true,
+    "UseShorthandTypeNames" : true,
+    "UseSingleLinePropertyGetter" : true,
+    "UseSynthesizedInitializer" : true,
+    "UseTripleSlashForDocumentationComments" : true,
+    "ValidateDocumentationComments" : true
+  },
+  "tabWidth" : 4,
+  "version" : 1
+}

--- a/ExampleApp/ExampleApp/AdvancedFeatures/CommandsExampleViewController.swift
+++ b/ExampleApp/ExampleApp/AdvancedFeatures/CommandsExampleViewController.swift
@@ -7,9 +7,8 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 class EditorCommandButton: UIButton {
     let command: EditorCommand
@@ -94,9 +93,12 @@ class CommandsExampleViewController: ExamplesBaseViewController {
         scrollView.addSubview(stackView)
 
         NSLayoutConstraint.activate([
-            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 20),
-            scrollView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
-            scrollView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
+            scrollView.topAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 20),
+            scrollView.leadingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
+            scrollView.trailingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
 
             scrollView.heightAnchor.constraint(equalTo: stackView.heightAnchor, constant: 10),
 
@@ -107,8 +109,10 @@ class CommandsExampleViewController: ExamplesBaseViewController {
             stackView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
 
             editor.topAnchor.constraint(equalTo: stackView.bottomAnchor, constant: 20),
-            editor.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
-            editor.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
+            editor.leadingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
+            editor.trailingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
             editor.heightAnchor.constraint(greaterThanOrEqualToConstant: 100),
             editor.heightAnchor.constraint(lessThanOrEqualToConstant: 300),
         ])
@@ -173,8 +177,8 @@ class CommandsExampleViewController: ExamplesBaseViewController {
         self.encodedContents = ["contents": value]
 
         let printableContents = """
-            { "contents":  \(jsonString) }
-        """
+                { "contents":  \(jsonString) }
+            """
 
         print(printableContents)
 
@@ -183,7 +187,8 @@ class CommandsExampleViewController: ExamplesBaseViewController {
 
     @objc
     func decodeContents(sender: UIButton) {
-        let text = EditorContentJSONDecoder().decode(mode: .editor, maxSize: editor.frame.size, value: encodedContents)
+        let text = EditorContentJSONDecoder().decode(
+            mode: .editor, maxSize: editor.frame.size, value: encodedContents)
         self.editor.attributedText = text
     }
 
@@ -193,7 +198,8 @@ class CommandsExampleViewController: ExamplesBaseViewController {
             return
         }
 
-        let text = EditorContentJSONDecoder().decode(mode: .editor, maxSize: editor.frame.size, value: contents)
+        let text = EditorContentJSONDecoder().decode(
+            mode: .editor, maxSize: editor.frame.size, value: contents)
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
             self.editor.attributedText = text
         }
@@ -201,7 +207,10 @@ class CommandsExampleViewController: ExamplesBaseViewController {
 }
 
 extension CommandsExampleViewController: EditorViewDelegate {
-    func editor(_ editor: EditorView, didChangeSelectionAt range: NSRange, attributes: [NSAttributedString.Key: Any], contentType: EditorContent.Name) {
+    func editor(
+        _ editor: EditorView, didChangeSelectionAt range: NSRange,
+        attributes: [NSAttributedString.Key: Any], contentType: EditorContent.Name
+    ) {
         guard let font = attributes[.font] as? UIFont else { return }
 
         buttons.first(where: { $0.titleLabel?.text == "Bold" })?.isSelected = font.isBold

--- a/ExampleApp/ExampleApp/AdvancedFeatures/TextProcessorExampleViewController.swift
+++ b/ExampleApp/ExampleApp/AdvancedFeatures/TextProcessorExampleViewController.swift
@@ -7,9 +7,8 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 class TextProcessorExampleViewController: ExamplesBaseViewController {
 
@@ -29,13 +28,15 @@ class TextProcessorExampleViewController: ExamplesBaseViewController {
 
         NSLayoutConstraint.activate([
             editor.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 20),
-            editor.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
-            editor.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
+            editor.leadingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
+            editor.trailingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
             editor.heightAnchor.constraint(greaterThanOrEqualToConstant: 100),
             editor.heightAnchor.constraint(lessThanOrEqualToConstant: 300),
 
             typeaheadLabel.topAnchor.constraint(equalTo: editor.bottomAnchor, constant: 50),
-            typeaheadLabel.leadingAnchor.constraint(equalTo: editor.leadingAnchor)
+            typeaheadLabel.leadingAnchor.constraint(equalTo: editor.leadingAnchor),
         ])
 
         registerTextProcessors()

--- a/ExampleApp/ExampleApp/AppDelegate.swift
+++ b/ExampleApp/ExampleApp/AppDelegate.swift
@@ -13,11 +13,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
 
     var window: UIWindow?
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+    ) -> Bool {
         // Override point for customization after application launch.
         let splitViewController = window!.rootViewController as! UISplitViewController
-        let navigationController = splitViewController.viewControllers[splitViewController.viewControllers.count-1] as! UINavigationController
-        navigationController.topViewController!.navigationItem.leftBarButtonItem = splitViewController.displayModeButtonItem
+        let navigationController =
+            splitViewController.viewControllers[splitViewController.viewControllers.count - 1]
+                as! UINavigationController
+        navigationController.topViewController!.navigationItem.leftBarButtonItem =
+            splitViewController.displayModeButtonItem
         splitViewController.delegate = self
         return true
     }

--- a/ExampleApp/ExampleApp/Attachments/FixedWidthAttachmentExampleViewController.swift
+++ b/ExampleApp/ExampleApp/Attachments/FixedWidthAttachmentExampleViewController.swift
@@ -7,15 +7,15 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 class FixedWidthAttachmentExampleViewController: ExamplesBaseViewController {
     let widthTextField = UITextField()
 
     var width: CGFloat {
-        let width = CGFloat(exactly: NumberFormatter().number(from: widthTextField.text ?? "") ?? 100) ?? 100
+        let width = CGFloat(
+            exactly: NumberFormatter().number(from: widthTextField.text ?? "") ?? 100) ?? 100
         return width
     }
 
@@ -50,9 +50,11 @@ class FixedWidthAttachmentExampleViewController: ExamplesBaseViewController {
             widthTextField.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
 
             editor.topAnchor.constraint(equalTo: button.bottomAnchor, constant: 20),
-            editor.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
-            editor.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
-            editor.heightAnchor.constraint(greaterThanOrEqualToConstant: 100)
+            editor.leadingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
+            editor.trailingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
+            editor.heightAnchor.constraint(greaterThanOrEqualToConstant: 100),
         ])
     }
 
@@ -74,7 +76,11 @@ class FixedWidthAttachmentExampleViewController: ExamplesBaseViewController {
 }
 
 extension FixedWidthAttachmentExampleViewController: AttachmentOffsetProviding {
-    func offset(for attachment: Attachment, in textContainer: NSTextContainer, proposedLineFragment lineFrag: CGRect, glyphPosition position: CGPoint, characterIndex charIndex: Int) -> CGPoint {
+    func offset(
+        for attachment: Attachment, in textContainer: NSTextContainer,
+        proposedLineFragment lineFrag: CGRect, glyphPosition position: CGPoint,
+        characterIndex charIndex: Int
+    ) -> CGPoint {
         return CGPoint(x: 0, y: -2)
     }
 }

--- a/ExampleApp/ExampleApp/Attachments/FullWidthAttachmentExampleViewController.swift
+++ b/ExampleApp/ExampleApp/Attachments/FullWidthAttachmentExampleViewController.swift
@@ -7,9 +7,8 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 class FullWidthAttachmentExampleViewController: ExamplesBaseViewController {
 
@@ -34,9 +33,11 @@ class FullWidthAttachmentExampleViewController: ExamplesBaseViewController {
             button.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
 
             editor.topAnchor.constraint(equalTo: button.bottomAnchor, constant: 20),
-            editor.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
-            editor.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
-            editor.heightAnchor.constraint(greaterThanOrEqualToConstant: 100)
+            editor.leadingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
+            editor.trailingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
+            editor.heightAnchor.constraint(greaterThanOrEqualToConstant: 100),
         ])
     }
 

--- a/ExampleApp/ExampleApp/Attachments/MatchContentAttachmentExampleViewController.swift
+++ b/ExampleApp/ExampleApp/Attachments/MatchContentAttachmentExampleViewController.swift
@@ -7,9 +7,8 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 class MatchContentAttachmentExampleViewController: ExamplesBaseViewController {
 
@@ -37,9 +36,11 @@ class MatchContentAttachmentExampleViewController: ExamplesBaseViewController {
             button.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
 
             editor.topAnchor.constraint(equalTo: button.bottomAnchor, constant: 20),
-            editor.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
-            editor.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
-            editor.heightAnchor.constraint(greaterThanOrEqualToConstant: 100)
+            editor.leadingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
+            editor.trailingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
+            editor.heightAnchor.constraint(greaterThanOrEqualToConstant: 100),
         ])
     }
 
@@ -61,7 +62,11 @@ class MatchContentAttachmentExampleViewController: ExamplesBaseViewController {
 }
 
 extension MatchContentAttachmentExampleViewController: AttachmentOffsetProviding {
-    func offset(for attachment: Attachment, in textContainer: NSTextContainer, proposedLineFragment lineFrag: CGRect, glyphPosition position: CGPoint, characterIndex charIndex: Int) -> CGPoint {
+    func offset(
+        for attachment: Attachment, in textContainer: NSTextContainer,
+        proposedLineFragment lineFrag: CGRect, glyphPosition position: CGPoint,
+        characterIndex charIndex: Int
+    ) -> CGPoint {
         return CGPoint(x: 0, y: -8)
     }
 }

--- a/ExampleApp/ExampleApp/Attachments/PercentWidthAttachmentExampleViewController.swift
+++ b/ExampleApp/ExampleApp/Attachments/PercentWidthAttachmentExampleViewController.swift
@@ -7,15 +7,15 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 class PercentWidthAttachmentExampleViewController: ExamplesBaseViewController {
     let widthTextField = UITextField()
 
     var width: CGFloat {
-        let width = CGFloat(exactly: NumberFormatter().number(from: widthTextField.text ?? "") ?? 50) ?? 50
+        let width = CGFloat(
+            exactly: NumberFormatter().number(from: widthTextField.text ?? "") ?? 50) ?? 50
         return width
     }
 
@@ -50,9 +50,11 @@ class PercentWidthAttachmentExampleViewController: ExamplesBaseViewController {
             widthTextField.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
 
             editor.topAnchor.constraint(equalTo: button.bottomAnchor, constant: 20),
-            editor.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
-            editor.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
-            editor.heightAnchor.constraint(greaterThanOrEqualToConstant: 100)
+            editor.leadingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
+            editor.trailingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
+            editor.heightAnchor.constraint(greaterThanOrEqualToConstant: 100),
         ])
     }
 
@@ -74,7 +76,11 @@ class PercentWidthAttachmentExampleViewController: ExamplesBaseViewController {
 }
 
 extension PercentWidthAttachmentExampleViewController: AttachmentOffsetProviding {
-    func offset(for attachment: Attachment, in textContainer: NSTextContainer, proposedLineFragment lineFrag: CGRect, glyphPosition position: CGPoint, characterIndex charIndex: Int) -> CGPoint {
+    func offset(
+        for attachment: Attachment, in textContainer: NSTextContainer,
+        proposedLineFragment lineFrag: CGRect, glyphPosition position: CGPoint,
+        characterIndex charIndex: Int
+    ) -> CGPoint {
         return CGPoint(x: 0, y: -2)
     }
 }

--- a/ExampleApp/ExampleApp/Attachments/WidthRangeAttachmentExampleViewController.swift
+++ b/ExampleApp/ExampleApp/Attachments/WidthRangeAttachmentExampleViewController.swift
@@ -7,21 +7,22 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 class WidthRangeAttachmentExampleViewController: ExamplesBaseViewController {
     let minWidthTextField = UITextField()
     let maxWidthTextField = UITextField()
 
     var minWidth: CGFloat {
-        let width = CGFloat(exactly: NumberFormatter().number(from: minWidthTextField.text ?? "") ?? 40) ?? 40
+        let width = CGFloat(
+            exactly: NumberFormatter().number(from: minWidthTextField.text ?? "") ?? 40) ?? 40
         return width
     }
 
     var maxWidth: CGFloat {
-        let width = CGFloat(exactly: NumberFormatter().number(from: maxWidthTextField.text ?? "") ?? 120) ?? 120
+        let width = CGFloat(
+            exactly: NumberFormatter().number(from: maxWidthTextField.text ?? "") ?? 120) ?? 120
         return width
     }
 
@@ -55,7 +56,8 @@ class WidthRangeAttachmentExampleViewController: ExamplesBaseViewController {
 
         NSLayoutConstraint.activate([
             button.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 20),
-            button.leadingAnchor.constraint(equalTo: maxWidthTextField.trailingAnchor, constant: 10),
+            button.leadingAnchor.constraint(
+                equalTo: maxWidthTextField.trailingAnchor, constant: 10),
 
             minWidthTextField.topAnchor.constraint(equalTo: button.topAnchor),
             minWidthTextField.widthAnchor.constraint(equalToConstant: 60),
@@ -63,12 +65,15 @@ class WidthRangeAttachmentExampleViewController: ExamplesBaseViewController {
 
             maxWidthTextField.topAnchor.constraint(equalTo: button.topAnchor),
             maxWidthTextField.widthAnchor.constraint(equalToConstant: 60),
-            maxWidthTextField.leadingAnchor.constraint(equalTo: minWidthTextField.trailingAnchor, constant: 10),
+            maxWidthTextField.leadingAnchor.constraint(
+                equalTo: minWidthTextField.trailingAnchor, constant: 10),
 
             editor.topAnchor.constraint(equalTo: button.bottomAnchor, constant: 20),
-            editor.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
-            editor.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
-            editor.heightAnchor.constraint(greaterThanOrEqualToConstant: 100)
+            editor.leadingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
+            editor.trailingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
+            editor.heightAnchor.constraint(greaterThanOrEqualToConstant: 100),
         ])
     }
 
@@ -90,7 +95,11 @@ class WidthRangeAttachmentExampleViewController: ExamplesBaseViewController {
 }
 
 extension WidthRangeAttachmentExampleViewController: AttachmentOffsetProviding {
-    func offset(for attachment: Attachment, in textContainer: NSTextContainer, proposedLineFragment lineFrag: CGRect, glyphPosition position: CGPoint, characterIndex charIndex: Int) -> CGPoint {
+    func offset(
+        for attachment: Attachment, in textContainer: NSTextContainer,
+        proposedLineFragment lineFrag: CGRect, glyphPosition position: CGPoint,
+        characterIndex charIndex: Int
+    ) -> CGPoint {
         return CGPoint(x: 0, y: -2)
     }
 }

--- a/ExampleApp/ExampleApp/Basic/AutogrowingEditorViewExampleViewController.swift
+++ b/ExampleApp/ExampleApp/Basic/AutogrowingEditorViewExampleViewController.swift
@@ -7,9 +7,8 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 class AutogrowingEditorViewExampleViewController: ExamplesBaseViewController {
 
@@ -24,10 +23,12 @@ class AutogrowingEditorViewExampleViewController: ExamplesBaseViewController {
 
         NSLayoutConstraint.activate([
             editor.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 20),
-            editor.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
-            editor.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
+            editor.leadingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
+            editor.trailingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
             editor.heightAnchor.constraint(greaterThanOrEqualToConstant: 100),
-            editor.heightAnchor.constraint(lessThanOrEqualToConstant: 200)
+            editor.heightAnchor.constraint(lessThanOrEqualToConstant: 200),
         ])
 
         editor.placeholderText = NSAttributedString(
@@ -35,6 +36,6 @@ class AutogrowingEditorViewExampleViewController: ExamplesBaseViewController {
             attributes: [
                 .font: editor.font,
                 .foregroundColor: UIColor.tertiaryLabel,
-        ])
+            ])
     }
 }

--- a/ExampleApp/ExampleApp/BundleExtensions.swift
+++ b/ExampleApp/ExampleApp/BundleExtensions.swift
@@ -19,8 +19,9 @@ extension Bundle {
 
     func jsonFromFile(_ fileName: String) -> [String: Any]? {
         guard let data = dataFromFile(fileName, fileExtension: "json"),
-            let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] else {
-                return nil
+            let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
+        else {
+            return nil
         }
         return json
     }

--- a/ExampleApp/ExampleApp/Commands/DummyCollabCommand.swift
+++ b/ExampleApp/ExampleApp/Commands/DummyCollabCommand.swift
@@ -7,9 +7,8 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 class DummyCollabCommand: EditorCommand {
     func execute(on editor: EditorView) {
@@ -23,7 +22,8 @@ class DummyCollabCommand: EditorCommand {
         DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [editor] in
             let text = "collab edit "
             editor.replaceCharacters(in: .zero, with: text)
-            editor.selectedRange = NSRange(location: editor.selectedRange.location + text.count, length: 0)
+            editor.selectedRange = NSRange(
+                location: editor.selectedRange.location + text.count, length: 0)
             let insertedTextRange = NSRange(location: 0, length: text.count)
             let selectionRangeRect = editor.rects(for: insertedTextRange)
             let selectionView = UIView(frame: selectionRangeRect[0])

--- a/ExampleApp/ExampleApp/Commands/EncodeContentsCommand.swift
+++ b/ExampleApp/ExampleApp/Commands/EncodeContentsCommand.swift
@@ -7,9 +7,8 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 class EncodeContentsCommand: EditorCommand {
     func execute(on editor: EditorView) {

--- a/ExampleApp/ExampleApp/Commands/PanelCommand.swift
+++ b/ExampleApp/ExampleApp/Commands/PanelCommand.swift
@@ -7,9 +7,8 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 class PanelCommand: EditorCommand {
     func execute(on editor: EditorView) {

--- a/ExampleApp/ExampleApp/Commands/ResetCommand.swift
+++ b/ExampleApp/ExampleApp/Commands/ResetCommand.swift
@@ -7,16 +7,16 @@
 //
 
 import Foundation
-
 import Proton
 
 class ResetCommand: RendererCommand {
     func execute(on renderer: RendererView) {
-        renderer.attributedText = NSAttributedString(string: """
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus vel aliquam enim. Nam lobortis, ipsum ullamcorper accumsan aliquam, orci velit lobortis lacus, at volutpat augue sem at enim. Maecenas porta velit eget eleifend rutrum. Mauris vel dui diam. Suspendisse porttitor dictum massa, sit amet imperdiet mi facilisis a. Duis viverra facilisis justo, sit amet congue mauris. Nullam vitae pellentesque eros. Aenean ut erat ultrices, vulputate massa vel, ultricies velit. Nam at arcu lacinia, ullamcorper augue eget, lobortis dui. Vestibulum iaculis tortor id diam suscipit consectetur. Nulla sit amet pretium purus. Donec ac congue est, et porttitor dolor. Curabitur dictum, nunc et aliquam venenatis, quam nisi porta nunc, accumsan tincidunt magna tortor sed justo. Donec quis iaculis leo, sed feugiat lectus. Sed non libero nibh.
+        renderer.attributedText = NSAttributedString(
+            string: """
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus vel aliquam enim. Nam lobortis, ipsum ullamcorper accumsan aliquam, orci velit lobortis lacus, at volutpat augue sem at enim. Maecenas porta velit eget eleifend rutrum. Mauris vel dui diam. Suspendisse porttitor dictum massa, sit amet imperdiet mi facilisis a. Duis viverra facilisis justo, sit amet congue mauris. Nullam vitae pellentesque eros. Aenean ut erat ultrices, vulputate massa vel, ultricies velit. Nam at arcu lacinia, ullamcorper augue eget, lobortis dui. Vestibulum iaculis tortor id diam suscipit consectetur. Nulla sit amet pretium purus. Donec ac congue est, et porttitor dolor. Curabitur dictum, nunc et aliquam venenatis, quam nisi porta nunc, accumsan tincidunt magna tortor sed justo. Donec quis iaculis leo, sed feugiat lectus. Sed non libero nibh.
 
-            Donec dignissim sollicitudin diam, a egestas mi elementum ac. Fusce orci ligula, consectetur vel eleifend at, consectetur a turpis. Sed sed volutpat nisl. Donec vel sollicitudin turpis. Vivamus auctor iaculis dui, eget consectetur sapien. Nullam hendrerit egestas efficitur. Nam vestibulum massa libero, eget facilisis mauris eleifend nec. Mauris placerat semper eros, nec sagittis ipsum dapibus in. Curabitur faucibus est quis enim sodales, placerat sollicitudin eros blandit. Proin a fringilla augue. Morbi ullamcorper a metus quis placerat.
-        """
+                    Donec dignissim sollicitudin diam, a egestas mi elementum ac. Fusce orci ligula, consectetur vel eleifend at, consectetur a turpis. Sed sed volutpat nisl. Donec vel sollicitudin turpis. Vivamus auctor iaculis dui, eget consectetur sapien. Nullam hendrerit egestas efficitur. Nam vestibulum massa libero, eget facilisis mauris eleifend nec. Mauris placerat semper eros, nec sagittis ipsum dapibus in. Curabitur faucibus est quis enim sodales, placerat sollicitudin eros blandit. Proin a fringilla augue. Morbi ullamcorper a metus quis placerat.
+                """
         )
     }
 }

--- a/ExampleApp/ExampleApp/Commands/ScrollCommand.swift
+++ b/ExampleApp/ExampleApp/Commands/ScrollCommand.swift
@@ -7,9 +7,8 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 class ScrollCommand: RendererCommand {
     var text = "Fusce"
@@ -20,9 +19,12 @@ class ScrollCommand: RendererCommand {
         for content in renderer.contents(in: range) {
             if case let .text(_, attributedString) = content.type,
                 let range = attributedString.string.range(of: text, options: .caseInsensitive),
-                let enclosingRange = content.enclosingRange {
+                let enclosingRange = content.enclosingRange
+            {
                 let contentRange = attributedString.string.makeNSRange(from: range)
-                let scrollRange = NSRange(location: enclosingRange.location + contentRange.location + location, length: contentRange.length)
+                let scrollRange = NSRange(
+                    location: enclosingRange.location + contentRange.location + location,
+                    length: contentRange.length)
                 renderer.selectedRange = scrollRange
                 renderer.scrollRangeToVisible(scrollRange)
                 break

--- a/ExampleApp/ExampleApp/Decoding/AttributesDecoding.swift
+++ b/ExampleApp/ExampleApp/Decoding/AttributesDecoding.swift
@@ -7,9 +7,8 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 protocol AttributedStringAttributesDecoding {
     associatedtype TypeToDecode

--- a/ExampleApp/ExampleApp/Decoding/Decoder/PanelDecoder.swift
+++ b/ExampleApp/ExampleApp/Decoding/Decoder/PanelDecoder.swift
@@ -7,17 +7,17 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 struct PanelDecoder: EditorContentDecoding {
     func decode(mode: EditorContentMode, maxSize: CGSize, value: JSON) -> NSAttributedString {
         let frame = CGRect(origin: .zero, size: CGSize(width: 200, height: 30))
         let attachment = PanelAttachment(frame: frame)
-//        attachment.readOnly = (mode == .readOnly)
+        //        attachment.readOnly = (mode == .readOnly)
 
-        attachment.attributedText = EditorContentJSONDecoder().decode(mode: mode, maxSize: maxSize, value: value)
+        attachment.attributedText = EditorContentJSONDecoder().decode(
+            mode: mode, maxSize: maxSize, value: value)
         return attachment.string
     }
 }

--- a/ExampleApp/ExampleApp/Decoding/Decoder/ParagraphDecoder.swift
+++ b/ExampleApp/ExampleApp/Decoding/Decoder/ParagraphDecoder.swift
@@ -7,19 +7,20 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 struct ParagraphDecoder: EditorContentDecoding {
     func decode(mode: EditorContentMode, maxSize: CGSize, value: JSON) -> NSAttributedString {
         let string = NSMutableAttributedString()
         var attr = Attributes()
         if let style = value["style"] as? JSON,
-            let decoder = EditorContentJSONDecoder.attributeDecoders["style"] {
+            let decoder = EditorContentJSONDecoder.attributeDecoders["style"]
+        {
             attr = decoder.decode(style)
 
-            string.append(EditorContentJSONDecoder().decode(mode: mode, maxSize: maxSize, value: value))
+            string.append(
+                EditorContentJSONDecoder().decode(mode: mode, maxSize: maxSize, value: value))
         }
         string.append(NSAttributedString(string: "\n"))
         string.addAttributes(attr, range: string.fullRange)

--- a/ExampleApp/ExampleApp/Decoding/Decoder/ParagraphStyleDecoder.swift
+++ b/ExampleApp/ExampleApp/Decoding/Decoder/ParagraphStyleDecoder.swift
@@ -7,17 +7,18 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 struct ParagraphStyleDecoder: AttributedStringAttributesDecoding {
     var name: String { return "style" }
 
     func decode(_ json: JSON) -> Attributes {
         let style = NSMutableParagraphStyle()
-        style.alignment = NSTextAlignment(rawValue: json["alignment"] as? Int ?? 0) ?? style.alignment
-        style.firstLineHeadIndent = json["firstLineHeadIndent"] as? CGFloat ?? style.firstLineHeadIndent
+        style.alignment = NSTextAlignment(rawValue: json["alignment"] as? Int ?? 0)
+            ?? style.alignment
+        style.firstLineHeadIndent = json["firstLineHeadIndent"] as? CGFloat
+            ?? style.firstLineHeadIndent
         style.lineSpacing = json["linespacing"] as? CGFloat ?? style.lineSpacing
         style.paragraphSpacing = json["paragraphSpacing"] as? CGFloat ?? style.paragraphSpacing
         return [.paragraphStyle: style]

--- a/ExampleApp/ExampleApp/Decoding/Decoder/TextDecoder.swift
+++ b/ExampleApp/ExampleApp/Decoding/Decoder/TextDecoder.swift
@@ -7,16 +7,16 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 struct TextDecoder: EditorContentDecoding {
     func decode(mode: EditorContentMode, maxSize: CGSize, value: JSON) -> NSAttributedString {
         let text = value["text"] as? String ?? ""
         let string = NSMutableAttributedString(string: text)
         if let font = value["font"] as? JSON,
-            let decoder = EditorContentJSONDecoder.attributeDecoders["font"] {
+            let decoder = EditorContentJSONDecoder.attributeDecoders["font"]
+        {
             let attr = decoder.decode(font)
             string.addAttributes(attr, range: string.fullRange)
         }

--- a/ExampleApp/ExampleApp/Decoding/Decoder/UIFontDecoder.swift
+++ b/ExampleApp/ExampleApp/Decoding/Decoder/UIFontDecoder.swift
@@ -7,9 +7,8 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 struct UIFontDecoder: AttributedStringAttributesDecoding {
     var name: String { return "font" }
@@ -18,8 +17,9 @@ struct UIFontDecoder: AttributedStringAttributesDecoding {
         guard
             let size = json["size"] as? CGFloat,
             let style = json["textStyle"] as? String,
-            let family = json["family"] as? String else {
-                return [.font: UIFont.preferredFont(forTextStyle: .body)]
+            let family = json["family"] as? String
+        else {
+            return [.font: UIFont.preferredFont(forTextStyle: .body)]
         }
 
         let textStyle = UIFont.TextStyle(rawValue: style)

--- a/ExampleApp/ExampleApp/Decoding/JSONDecoder.swift
+++ b/ExampleApp/ExampleApp/Decoding/JSONDecoder.swift
@@ -7,15 +7,14 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 struct EditorContentJSONDecoder: EditorContentDecoding {
     static let contentDecoders: [EditorContent.Name: AnyEditorContentDecoding<JSON>] = [
         EditorContent.Name.paragraph: AnyEditorContentDecoding(ParagraphDecoder()),
         EditorContent.Name.text: AnyEditorContentDecoding(TextDecoder()),
-        EditorContent.Name("panel"): AnyEditorContentDecoding(PanelDecoder())
+        EditorContent.Name("panel"): AnyEditorContentDecoding(PanelDecoder()),
     ]
 
     static let attributeDecoders: [String: AnyAttributedStringAttributeDecoding<JSON>] = [
@@ -29,7 +28,8 @@ struct EditorContentJSONDecoder: EditorContentDecoding {
             if let type = content.type {
                 let typeName = EditorContent.Name(type)
                 let decoder = EditorContentJSONDecoder.contentDecoders[typeName]
-                let contentValue = decoder?.decode(mode: mode, maxSize: maxSize, value: content) ?? NSAttributedString()
+                let contentValue = decoder?.decode(mode: mode, maxSize: maxSize, value: content)
+                    ?? NSAttributedString()
                 string.append(contentValue)
             }
         }

--- a/ExampleApp/ExampleApp/Encoding/Encoders/PanelEncoder.swift
+++ b/ExampleApp/ExampleApp/Encoding/Encoders/PanelEncoder.swift
@@ -7,9 +7,8 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 struct PanelEncoder: AttachmentEncoding {
     func encode(name: EditorContent.Name, view: UIView) -> JSON {

--- a/ExampleApp/ExampleApp/Encoding/Encoders/ParagraphEncoder.swift
+++ b/ExampleApp/ExampleApp/Encoding/Encoders/ParagraphEncoder.swift
@@ -7,9 +7,8 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 extension JSON {
     var type: String? {
@@ -27,7 +26,9 @@ struct ParagraphEncoder: EditorTextEncoding {
     func encode(name: EditorContent.Name, string: NSAttributedString) -> JSON {
         var paragraph = JSON()
         paragraph.type = name.rawValue
-        if let style = string.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle {
+        if let style = string.attribute(.paragraphStyle, at: 0, effectiveRange: nil)
+            as? NSParagraphStyle
+        {
             paragraph[style.key] = style.value
         }
         paragraph.contents = contentsFrom(string)

--- a/ExampleApp/ExampleApp/Encoding/Encoders/ParagraphStyle+Codables.swift
+++ b/ExampleApp/ExampleApp/Encoding/Encoders/ParagraphStyle+Codables.swift
@@ -22,7 +22,7 @@ extension NSParagraphStyle: Encoding {
             "alignment": alignment.rawValue,
             "firstLineHeadIndent": firstLineHeadIndent,
             "linespacing": lineSpacing,
-            "paragraphSpacing": paragraphSpacing
+            "paragraphSpacing": paragraphSpacing,
         ]
         return attributes
     }
@@ -39,7 +39,8 @@ extension UIFont: InlineEncoding {
             "isBold": fontDescriptor.symbolicTraits.contains(.traitBold),
             "isItalics": fontDescriptor.symbolicTraits.contains(.traitItalic),
             "isMonospace": fontDescriptor.symbolicTraits.contains(.traitMonoSpace),
-            "textStyle": fontDescriptor.object(forKey: .textStyle) as? String ?? "UICTFontTextStyleBody"
+            "textStyle": fontDescriptor.object(forKey: .textStyle) as? String
+                ?? "UICTFontTextStyleBody",
         ]
         return .json(value: attributes)
     }

--- a/ExampleApp/ExampleApp/Encoding/Encoders/TextEncoder.swift
+++ b/ExampleApp/ExampleApp/Encoding/Encoders/TextEncoder.swift
@@ -7,9 +7,8 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 enum InlineValueType {
     case single(value: Any?)
@@ -24,7 +23,8 @@ protocol InlineEncoding {
 struct TextEncoder: EditorTextEncoding {
     func encode(name: EditorContent.Name, string: NSAttributedString) -> JSON {
         var text = JSON()
-        string.enumerateAttributes(in: string.fullRange, options: .longestEffectiveRangeNotRequired) { (attributes, range, _) in
+        string.enumerateAttributes(in: string.fullRange, options: .longestEffectiveRangeNotRequired)
+        { (attributes, range, _) in
             let substring = string.attributedSubstring(from: range)
             text.type = name.rawValue
             text["text"] = substring.string

--- a/ExampleApp/ExampleApp/Encoding/JSONEncoder.swift
+++ b/ExampleApp/ExampleApp/Encoding/JSONEncoder.swift
@@ -7,16 +7,15 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 typealias JSON = [String: Any]
 
 struct JSONEncoder: EditorContentEncoder {
     let textEncoders: [EditorContent.Name: AnyEditorTextEncoding<JSON>] = [
         EditorContent.Name.paragraph: AnyEditorTextEncoding(ParagraphEncoder()),
-        .text: AnyEditorTextEncoding(TextEncoder())
+        .text: AnyEditorTextEncoding(TextEncoder()),
     ]
 
     let attachmentEncoders: [EditorContent.Name: AnyEditorContentAttachmentEncoding<JSON>] = [

--- a/ExampleApp/ExampleApp/ExamplesBaseViewController.swift
+++ b/ExampleApp/ExampleApp/ExamplesBaseViewController.swift
@@ -7,9 +7,8 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 class ExamplesBaseViewController: UIViewController {
 

--- a/ExampleApp/ExampleApp/Helpers/UIViewExtensions.swift
+++ b/ExampleApp/ExampleApp/Helpers/UIViewExtensions.swift
@@ -9,8 +9,11 @@
 import Foundation
 import UIKit
 
-public extension UIView {
-    func flash(numberOfFlashes: Float = 2, maxOpacity: Float = 0.5, minOpacity: Float = 0.1, onCompletion completion: ((UIView) -> Void)? = nil) {
+extension UIView {
+    public func flash(
+        numberOfFlashes: Float = 2, maxOpacity: Float = 0.5, minOpacity: Float = 0.1,
+        onCompletion completion: ((UIView) -> Void)? = nil
+    ) {
         CATransaction.begin()
         CATransaction.setCompletionBlock {
             completion?(self)
@@ -26,10 +29,12 @@ public extension UIView {
         CATransaction.commit()
     }
 
-    func blink() {
+    public func blink() {
         self.alpha = 1
-        UIView.animate(withDuration: 1.0, delay: 0, options: [.repeat], animations: {
-            self.alpha = 0
-        }, completion: nil)
+        UIView.animate(
+            withDuration: 1.0, delay: 0, options: [.repeat],
+            animations: {
+                self.alpha = 0
+            }, completion: nil)
     }
 }

--- a/ExampleApp/ExampleApp/MasterViewController.swift
+++ b/ExampleApp/ExampleApp/MasterViewController.swift
@@ -21,23 +21,44 @@ struct NavigationItem {
 class MasterViewController: UITableViewController {
 
     let navigation = [
-        Navigation(title: "Basic features", items: [
-            NavigationItem(title: "Autogrowing Editor", viewController: AutogrowingEditorViewExampleViewController()),
-        ]),
-        Navigation(title: "Attachment", items: [
-            NavigationItem(title: "Match Content", viewController: MatchContentAttachmentExampleViewController()),
-            NavigationItem(title: "Full Width", viewController: FullWidthAttachmentExampleViewController()),
-            NavigationItem(title: "Fixed Width", viewController: FixedWidthAttachmentExampleViewController()),
-            NavigationItem(title: "Width Range", viewController: WidthRangeAttachmentExampleViewController()),
-            NavigationItem(title: "Percent Width", viewController: PercentWidthAttachmentExampleViewController()),
-        ]),
-        Navigation(title: "Advanced features", items: [
-            NavigationItem(title: "Commands", viewController: CommandsExampleViewController()),
-            NavigationItem(title: "Text Processors", viewController: TextProcessorExampleViewController()),
-        ]),
-        Navigation(title: "Renderer", items: [
-            NavigationItem(title: "Commands", viewController: RendererCommandsExampleViewController())
-        ]),
+        Navigation(
+            title: "Basic features",
+            items: [
+                NavigationItem(
+                    title: "Autogrowing Editor",
+                    viewController: AutogrowingEditorViewExampleViewController()),
+            ]),
+        Navigation(
+            title: "Attachment",
+            items: [
+                NavigationItem(
+                    title: "Match Content",
+                    viewController: MatchContentAttachmentExampleViewController()),
+                NavigationItem(
+                    title: "Full Width", viewController: FullWidthAttachmentExampleViewController()),
+                NavigationItem(
+                    title: "Fixed Width",
+                    viewController: FixedWidthAttachmentExampleViewController()),
+                NavigationItem(
+                    title: "Width Range",
+                    viewController: WidthRangeAttachmentExampleViewController()),
+                NavigationItem(
+                    title: "Percent Width",
+                    viewController: PercentWidthAttachmentExampleViewController()),
+            ]),
+        Navigation(
+            title: "Advanced features",
+            items: [
+                NavigationItem(title: "Commands", viewController: CommandsExampleViewController()),
+                NavigationItem(
+                    title: "Text Processors", viewController: TextProcessorExampleViewController()),
+            ]),
+        Navigation(
+            title: "Renderer",
+            items: [
+                NavigationItem(
+                    title: "Commands", viewController: RendererCommandsExampleViewController())
+            ]),
     ]
 
     override func viewWillAppear(_ animated: Bool) {
@@ -51,7 +72,9 @@ class MasterViewController: UITableViewController {
         return navigation.count
     }
 
-    override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+    override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int)
+        -> String?
+    {
         navigation[section].title
     }
 
@@ -59,7 +82,9 @@ class MasterViewController: UITableViewController {
         return navigation[section].items.count
     }
 
-    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath)
+        -> UITableViewCell
+    {
         let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath)
         cell.textLabel!.text = navigation.item(at: indexPath).title
         cell.accessoryType = .disclosureIndicator

--- a/ExampleApp/ExampleApp/Renderer/RendererCommandExampleViewController.swift
+++ b/ExampleApp/ExampleApp/Renderer/RendererCommandExampleViewController.swift
@@ -7,9 +7,8 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 class RendererCommandButton: UIButton {
     var command: RendererCommand!
@@ -65,7 +64,8 @@ class RendererCommandsExampleViewController: ExamplesBaseViewController {
         view.addSubview(searchText)
 
         NSLayoutConstraint.activate([
-            stackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 20),
+            stackView.topAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 20),
             stackView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
 
             searchText.topAnchor.constraint(equalTo: stackView.bottomAnchor, constant: 20),
@@ -73,20 +73,23 @@ class RendererCommandsExampleViewController: ExamplesBaseViewController {
             searchText.widthAnchor.constraint(equalToConstant: 300),
 
             renderer.topAnchor.constraint(equalTo: searchText.bottomAnchor, constant: 20),
-            renderer.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
-            renderer.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
-            renderer.heightAnchor.constraint(equalToConstant: 300)
+            renderer.leadingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
+            renderer.trailingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
+            renderer.heightAnchor.constraint(equalToConstant: 300),
         ])
 
         setText()
     }
 
     func setText() {
-        renderer.attributedText = NSAttributedString(string: """
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus vel aliquam enim. Nam lobortis, ipsum ullamcorper accumsan aliquam, orci velit lobortis lacus, at volutpat augue sem at enim. Maecenas porta velit eget eleifend rutrum. Mauris vel dui diam. Suspendisse porttitor dictum massa, sit amet imperdiet mi facilisis a. Duis viverra facilisis justo, sit amet congue mauris. Nullam vitae pellentesque eros. Aenean ut erat ultrices, vulputate massa vel, ultricies velit. Nam at arcu lacinia, ullamcorper augue eget, lobortis dui. Vestibulum iaculis tortor id diam suscipit consectetur. Nulla sit amet pretium purus. Donec ac congue est, et porttitor dolor. Curabitur dictum, nunc et aliquam venenatis, quam nisi porta nunc, accumsan tincidunt magna tortor sed justo. Donec quis iaculis leo, sed feugiat lectus. Sed non libero nibh.
+        renderer.attributedText = NSAttributedString(
+            string: """
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus vel aliquam enim. Nam lobortis, ipsum ullamcorper accumsan aliquam, orci velit lobortis lacus, at volutpat augue sem at enim. Maecenas porta velit eget eleifend rutrum. Mauris vel dui diam. Suspendisse porttitor dictum massa, sit amet imperdiet mi facilisis a. Duis viverra facilisis justo, sit amet congue mauris. Nullam vitae pellentesque eros. Aenean ut erat ultrices, vulputate massa vel, ultricies velit. Nam at arcu lacinia, ullamcorper augue eget, lobortis dui. Vestibulum iaculis tortor id diam suscipit consectetur. Nulla sit amet pretium purus. Donec ac congue est, et porttitor dolor. Curabitur dictum, nunc et aliquam venenatis, quam nisi porta nunc, accumsan tincidunt magna tortor sed justo. Donec quis iaculis leo, sed feugiat lectus. Sed non libero nibh.
 
-            Donec dignissim sollicitudin diam, a egestas mi elementum ac. Fusce orci ligula, consectetur vel eleifend at, consectetur a turpis. Sed sed volutpat nisl. Donec vel sollicitudin turpis. Vivamus auctor iaculis dui, eget consectetur sapien. Nullam hendrerit egestas efficitur. Nam vestibulum massa libero, eget facilisis mauris eleifend nec. Mauris placerat semper eros, nec sagittis ipsum dapibus in. Curabitur faucibus est quis enim sodales, placerat sollicitudin eros blandit. Proin a fringilla augue. Morbi ullamcorper a metus quis placerat.
-        """
+                    Donec dignissim sollicitudin diam, a egestas mi elementum ac. Fusce orci ligula, consectetur vel eleifend at, consectetur a turpis. Sed sed volutpat nisl. Donec vel sollicitudin turpis. Vivamus auctor iaculis dui, eget consectetur sapien. Nullam hendrerit egestas efficitur. Nam vestibulum massa libero, eget facilisis mauris eleifend nec. Mauris placerat semper eros, nec sagittis ipsum dapibus in. Curabitur faucibus est quis enim sodales, placerat sollicitudin eros blandit. Proin a fringilla augue. Morbi ullamcorper a metus quis placerat.
+                """
         )
     }
 
@@ -119,7 +122,9 @@ class RendererCommandsExampleViewController: ExamplesBaseViewController {
 }
 
 extension RendererCommandsExampleViewController: RendererViewDelegate {
-    func didTap(_ renderer: RendererView, didTapAtLocation location: CGPoint, characterRange: NSRange?) {
+    func didTap(
+        _ renderer: RendererView, didTapAtLocation location: CGPoint, characterRange: NSRange?
+    ) {
         guard let charRange = characterRange else { return }
         print("Tapped: \(renderer.attributedText.attributedSubstring(from: charRange))")
     }

--- a/ExampleApp/ExampleApp/TextProcessors/MarkupTextProcessor.swift
+++ b/ExampleApp/ExampleApp/TextProcessors/MarkupTextProcessor.swift
@@ -7,9 +7,9 @@
 //
 
 import Foundation
+import Proton
 import UIKit
 
-import Proton
 class MarkupProcessor: TextProcessing {
     private let markupKey = NSAttributedString.Key(rawValue: "markup")
     private let rangeMarker = "start"
@@ -22,18 +22,23 @@ class MarkupProcessor: TextProcessing {
         return .medium
     }
 
-    func process(editor: EditorView, range editedRange: NSRange, changeInLength delta: Int) -> Processed {
+    func process(editor: EditorView, range editedRange: NSRange, changeInLength delta: Int)
+        -> Processed
+    {
         let textStorage = editor.attributedText
         let char = textStorage.attributedSubstring(from: editedRange)
 
         guard char.string == "*" else { return false }
 
-        guard let markupRange = textStorage.reverseRange(of: "*", currentPosition: editedRange.location),
-            let attr = textStorage.attribute(markupKey, at: markupRange.location, effectiveRange: nil) as? String,
+        guard
+            let markupRange = textStorage.reverseRange(
+                of: "*", currentPosition: editedRange.location),
+            let attr = textStorage.attribute(
+                markupKey, at: markupRange.location, effectiveRange: nil) as? String,
             attr == rangeMarker
-            else {
-                editor.addAttributes([markupKey: rangeMarker], at: editedRange)
-                return true
+        else {
+            editor.addAttributes([markupKey: rangeMarker], at: editedRange)
+            return true
         }
 
         let attrs = textStorage.attributes(at: markupRange.location, effectiveRange: nil)
@@ -49,9 +54,11 @@ class MarkupProcessor: TextProcessing {
     func processInterrupted(editor: EditorView, at range: NSRange) {
         let rangeToCheck = NSRange(location: 0, length: range.location)
         let textStorage = editor.attributedText
-        textStorage.enumerateAttribute(markupKey, in: rangeToCheck, options: .reverse) { val, range, stop in
+        textStorage.enumerateAttribute(markupKey, in: rangeToCheck, options: .reverse) {
+            val, range, stop in
             guard let value = val as? String,
-                value == rangeMarker else { return }
+                value == rangeMarker
+            else { return }
             editor.removeAttribute(markupKey, at: range)
             stop.pointee = true
         }

--- a/ExampleApp/ExampleApp/TextProcessors/TypeaheadTextProcessor.swift
+++ b/ExampleApp/ExampleApp/TextProcessors/TypeaheadTextProcessor.swift
@@ -7,9 +7,8 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 protocol TypeaheadTextProcessorDelegate: AnyObject {
     func typeaheadQueryDidChange(trigger: String, query: String, range: NSRange)
@@ -41,7 +40,8 @@ class TypeaheadTextProcessor: TextProcessing {
         let range = deleted.mutableString.range(of: "@")
         if range.location != NSNotFound {
             let triggerChar = deletedText.attributedSubstring(from: range)
-            let typeaheadAttribute = triggerChar.attribute(.typeahead, at: 0, effectiveRange: nil) as? Bool ?? true
+            let typeaheadAttribute = triggerChar.attribute(.typeahead, at: 0, effectiveRange: nil)
+                as? Bool ?? true
             if typeaheadAttribute != false {
                 triggerDeleted = true
                 delegate?.typeadheadQueryDidEnd(reason: .triggerDeleted)
@@ -49,7 +49,9 @@ class TypeaheadTextProcessor: TextProcessing {
         }
     }
 
-    func process(editor: EditorView, range editedRange: NSRange, changeInLength delta: Int) -> Processed {
+    func process(editor: EditorView, range editedRange: NSRange, changeInLength delta: Int)
+        -> Processed
+    {
         guard triggerDeleted == false else {
             editor.removeAttribute(.foregroundColor, at: editedRange)
             triggerDeleted = false
@@ -57,8 +59,11 @@ class TypeaheadTextProcessor: TextProcessing {
         }
 
         let textStorage = editor.attributedText
-        guard let range = textStorage.reverseRange(of: "@", currentPosition: editedRange.location + editedRange.length),
-            isValidTrigger(editor: editor, range: range.firstCharacterRange) else { return false }
+        guard
+            let range = textStorage.reverseRange(
+                of: "@", currentPosition: editedRange.location + editedRange.length),
+            isValidTrigger(editor: editor, range: range.firstCharacterRange)
+        else { return false }
 
         let triggerRange = NSRange(location: range.location, length: 1)
         let queryRange = NSRange(location: range.location + 1, length: range.length - 1)
@@ -83,7 +88,7 @@ class TypeaheadTextProcessor: TextProcessing {
         return true
     }
 
-    func processInterrupted(editor: EditorView, at range: NSRange) { }
+    func processInterrupted(editor: EditorView, at range: NSRange) {}
 
     private func isValidTrigger(editor: EditorView, range: NSRange) -> Bool {
         guard range != NSRange(location: 0, length: 1) else { return true }

--- a/ExampleApp/ExampleApp/Views/AutogrowingTextField.swift
+++ b/ExampleApp/ExampleApp/Views/AutogrowingTextField.swift
@@ -7,9 +7,8 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 class AutogrowingTextField: UITextField, UITextFieldDelegate {
     weak var boundsObserver: BoundsObserving?
@@ -22,7 +21,8 @@ class AutogrowingTextField: UITextField, UITextFieldDelegate {
     }
 
     override var intrinsicContentSize: CGSize {
-        let fittingSize = sizeThatFits(CGSize(width: .greatestFiniteMagnitude, height: frame.height))
+        let fittingSize = sizeThatFits(
+            CGSize(width: .greatestFiniteMagnitude, height: frame.height))
         // TODO: revisit to use invalidate intrinsic content size
         self.bounds = CGRect(origin: bounds.origin, size: fittingSize)
         return fittingSize

--- a/ExampleApp/ExampleApp/Views/PanelAttachment.swift
+++ b/ExampleApp/ExampleApp/Views/PanelAttachment.swift
@@ -7,9 +7,8 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 class PanelAttachment: Attachment {
     var view: PanelView
@@ -26,29 +25,46 @@ class PanelAttachment: Attachment {
         set { view.attributedText = newValue }
     }
 
-    override func addedAttributesOnContainingRange(rangeInContainer range: NSRange, attributes: [NSAttributedString.Key: Any]) {
+    override func addedAttributesOnContainingRange(
+        rangeInContainer range: NSRange, attributes: [NSAttributedString.Key: Any]
+    ) {
         view.editor.addAttributes(attributes, at: view.editor.attributedText.fullRange)
     }
 
-    override func removedAttributesFromContainingRange(rangeInContainer range: NSRange, attributes: [NSAttributedString.Key]) {
+    override func removedAttributesFromContainingRange(
+        rangeInContainer range: NSRange, attributes: [NSAttributedString.Key]
+    ) {
         view.editor.removeAttributes(attributes, at: view.editor.attributedText.fullRange)
     }
 }
 
 extension PanelAttachment: PanelViewDelegate {
-    func panel(_ panel: PanelView, didChangeSelectionAt range: NSRange, attributes: [NSAttributedString.Key: Any], contentType: EditorContent.Name) {
+    func panel(
+        _ panel: PanelView, didChangeSelectionAt range: NSRange,
+        attributes: [NSAttributedString.Key: Any], contentType: EditorContent.Name
+    ) {
         guard let containerEditor = self.containerEditorView else { return }
-        containerEditor.delegate?.editor(containerEditor, didChangeSelectionAt: range, attributes: attributes, contentType: contentType)
+        containerEditor.delegate?.editor(
+            containerEditor, didChangeSelectionAt: range, attributes: attributes,
+            contentType: contentType)
     }
 
-    func panel(_ panel: PanelView, didRecieveKey key: EditorKey, at range: NSRange, handled: inout Bool) {
-        if key == .backspace, range == .zero, panel.editor.attributedText.string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+    func panel(
+        _ panel: PanelView, didRecieveKey key: EditorKey, at range: NSRange, handled: inout Bool
+    ) {
+        if key == .backspace, range == .zero,
+            panel.editor.attributedText.string.trimmingCharacters(in: .whitespacesAndNewlines)
+                .isEmpty
+        {
             removeFromContainer()
             handled = true
         } else if key == .enter,
             let range = rangeInContainer()?.nextPosition,
-            let containerBounds = containerBounds {
-            let newAttachment = PanelAttachment(frame: CGRect(origin: .zero, size: CGSize(width: containerBounds.width, height: 30)))
+            let containerBounds = containerBounds
+        {
+            let newAttachment = PanelAttachment(
+                frame: CGRect(origin: .zero, size: CGSize(width: containerBounds.width, height: 30))
+            )
             self.containerEditorView?.insertAttachment(in: range, attachment: newAttachment)
             handled = true
         }

--- a/ExampleApp/ExampleApp/Views/PanelView.swift
+++ b/ExampleApp/ExampleApp/Views/PanelView.swift
@@ -7,17 +7,22 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 extension EditorContent.Name {
     static let panel = EditorContent.Name("panel")
 }
 
 protocol PanelViewDelegate: AnyObject {
-    func panel(_ panel: PanelView, didRecieveKey key: EditorKey, at range: NSRange, handled: inout Bool)
-    func panel(_ panel: PanelView, didChangeSelectionAt range: NSRange, attributes: [NSAttributedString.Key: Any], contentType: EditorContent.Name)
+    func panel(
+        _ panel: PanelView, didRecieveKey key: EditorKey, at range: NSRange, handled: inout Bool
+    )
+
+    func panel(
+        _ panel: PanelView, didChangeSelectionAt range: NSRange,
+        attributes: [NSAttributedString.Key: Any], contentType: EditorContent.Name
+    )
 }
 
 class PanelView: UIView, BlockContent, EditorContentView {
@@ -82,7 +87,8 @@ class PanelView: UIView, BlockContent, EditorContentView {
             iconView.topAnchor.constraint(equalTo: container.topAnchor, constant: 10),
             iconView.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 10),
 
-            editor.topAnchor.constraint(equalTo: iconView.topAnchor, constant: -editor.textContainerInset.top),
+            editor.topAnchor.constraint(
+                equalTo: iconView.topAnchor, constant: -editor.textContainerInset.top),
             editor.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: 5),
             editor.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -5),
             editor.bottomAnchor.constraint(equalTo: container.bottomAnchor),
@@ -99,15 +105,21 @@ class PanelView: UIView, BlockContent, EditorContentView {
 }
 
 extension PanelView: EditorViewDelegate {
-    func editor(_ editor: EditorView, didReceiveKey key: EditorKey, at range: NSRange, handled: inout Bool) {
+    func editor(
+        _ editor: EditorView, didReceiveKey key: EditorKey, at range: NSRange, handled: inout Bool
+    ) {
         delegate?.panel(self, didRecieveKey: key, at: range, handled: &handled)
     }
 
-    func editor(_ editor: EditorView, didChangeSelectionAt range: NSRange, attributes: [NSAttributedString.Key: Any], contentType: EditorContent.Name) {
+    func editor(
+        _ editor: EditorView, didChangeSelectionAt range: NSRange,
+        attributes: [NSAttributedString.Key: Any], contentType: EditorContent.Name
+    ) {
         // Relay the changed selection command to container `EditorView`'s delegate
         // This needs to be done as an additional step as container `EditorView`'s delegate is not registered as `PanelView`'s
         // editor as the `PanelView` register's itself as the `EditorView`'s delegate
-        delegate?.panel(self, didChangeSelectionAt: range, attributes: attributes, contentType: contentType)
+        delegate?.panel(
+            self, didChangeSelectionAt: range, attributes: attributes, contentType: contentType)
     }
 }
 

--- a/ExampleApp/ExampleAppTests/ExampleAppTests.swift
+++ b/ExampleApp/ExampleAppTests/ExampleAppTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+
 @testable import ExampleApp
 
 class ExampleAppTests: XCTestCase {

--- a/Proton/Sources/Attachment/Attachment.swift
+++ b/Proton/Sources/Attachment/Attachment.swift
@@ -23,7 +23,11 @@ public protocol DynamicBoundsProviding: AnyObject {
 /// While offset can be provided for any type of `Attachment` i.e. Inline or Block, it is recommended that offset be provided only for Inline. If an offset is provided for Block attachment,
 /// it is possible that the attachment starts overlapping the content in `Editor` in the following line since the offset does not affect the line height.
 public protocol AttachmentOffsetProviding: AnyObject {
-    func offset(for attachment: Attachment, in textContainer: NSTextContainer, proposedLineFragment lineFrag: CGRect, glyphPosition position: CGPoint, characterIndex charIndex: Int) -> CGPoint
+    func offset(
+        for attachment: Attachment, in textContainer: NSTextContainer,
+        proposedLineFragment lineFrag: CGRect, glyphPosition position: CGPoint,
+        characterIndex charIndex: Int
+    ) -> CGPoint
 }
 
 class AttachmentContentView: UIView {
@@ -86,9 +90,9 @@ open class Attachment: NSTextAttachment, BoundsObserving {
 
     func stringWithSpacers(appendPrev: Bool, appendNext: Bool) -> NSAttributedString {
         let updatedString = NSMutableAttributedString()
-//        if appendPrev {
-//            updatedString.append(spacer)
-//        }
+        //        if appendPrev {
+        //            updatedString.append(spacer)
+        //        }
         updatedString.append(string)
         if appendNext {
             updatedString.append(spacer)
@@ -97,15 +101,18 @@ open class Attachment: NSTextAttachment, BoundsObserving {
     }
 
     public var string: NSAttributedString {
-        guard let isBlockAttachment = isBlockAttachment else { return NSAttributedString(string: "<UNKNOWN CONTENT TYPE>") }
-//        let key = isBlockAttachment == true ? NSAttributedString.Key.contentType: NSAttributedString.Key.inlineContentType
+        guard let isBlockAttachment = isBlockAttachment else {
+            return NSAttributedString(string: "<UNKNOWN CONTENT TYPE>")
+        }
+        //        let key = isBlockAttachment == true ? NSAttributedString.Key.contentType: NSAttributedString.Key.inlineContentType
         let string = NSMutableAttributedString(attachment: self)
         let value = name ?? EditorContent.Name.unknown
-        string.addAttributes([
-            .contentType: value,
-            .isBlockAttachment: isBlockAttachment,
-            .isInlineAttachment: !isBlockAttachment
-        ], range: string.fullRange)
+        string.addAttributes(
+            [
+                .contentType: value,
+                .isBlockAttachment: isBlockAttachment,
+                .isInlineAttachment: !isBlockAttachment,
+            ], range: string.fullRange)
         return string
     }
 
@@ -152,7 +159,9 @@ open class Attachment: NSTextAttachment, BoundsObserving {
     }
 
     // This cannot be made convenience init as it prevents this being called from a class that inherits from `Attachment`
-    public init<AttachmentView: UIView & BlockContent>(_ contentView: AttachmentView, size: AttachmentSize) {
+    public init<AttachmentView: UIView & BlockContent>(
+        _ contentView: AttachmentView, size: AttachmentSize
+    ) {
         self.view = AttachmentContentView(name: contentView.name, frame: contentView.frame)
         self.size = size
         super.init(data: nil, ofType: nil)
@@ -162,7 +171,9 @@ open class Attachment: NSTextAttachment, BoundsObserving {
     }
 
     // This cannot be made convenience init as it prevents this being called from a class that inherits from `Attachment`
-    public init<AttachmentView: UIView & InlineContent>(_ contentView: AttachmentView, size: AttachmentSize) {
+    public init<AttachmentView: UIView & InlineContent>(
+        _ contentView: AttachmentView, size: AttachmentSize
+    ) {
         self.view = AttachmentContentView(name: contentView.name, frame: contentView.frame)
         self.size = size
         super.init(data: nil, ofType: nil)
@@ -194,23 +205,24 @@ open class Attachment: NSTextAttachment, BoundsObserving {
 
         NSLayoutConstraint.activate([
             contentView.topAnchor.constraint(equalTo: view.topAnchor),
-            contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: contentView.frame.height),
+            contentView.heightAnchor.constraint(
+                greaterThanOrEqualToConstant: contentView.frame.height),
             contentView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
         ])
 
         switch size {
         case .fullWidth, .matchContent, .percent:
             NSLayoutConstraint.activate([
-                contentView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+                contentView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             ])
         case let .fixed(width):
             NSLayoutConstraint.activate([
-                contentView.widthAnchor.constraint(equalToConstant: width)
+                contentView.widthAnchor.constraint(equalToConstant: width),
             ])
         case let .range(minWidth, maxWidth):
             NSLayoutConstraint.activate([
                 contentView.widthAnchor.constraint(greaterThanOrEqualToConstant: minWidth),
-                contentView.widthAnchor.constraint(lessThanOrEqualToConstant: maxWidth)
+                contentView.widthAnchor.constraint(lessThanOrEqualToConstant: maxWidth),
             ])
         }
     }
@@ -221,7 +233,8 @@ open class Attachment: NSTextAttachment, BoundsObserving {
 
     public func removeFromContainer() {
         guard let containerTextView = containerTextView,
-        let range = containerTextView.attributedText.rangeFor(attachment: self) else {
+            let range = containerTextView.attributedText.rangeFor(attachment: self)
+        else {
             return
         }
         containerTextView.textStorage.replaceCharacters(in: range, with: "")
@@ -231,11 +244,15 @@ open class Attachment: NSTextAttachment, BoundsObserving {
         return containerTextView?.attributedText.rangeFor(attachment: self)
     }
 
-    open func addedAttributesOnContainingRange(rangeInContainer range: NSRange, attributes: [NSAttributedString.Key: Any]) {
+    open func addedAttributesOnContainingRange(
+        rangeInContainer range: NSRange, attributes: [NSAttributedString.Key: Any]
+    ) {
 
     }
 
-    open func removedAttributesFromContainingRange(rangeInContainer range: NSRange, attributes: [NSAttributedString.Key]) {
+    open func removedAttributesFromContainingRange(
+        rangeInContainer range: NSRange, attributes: [NSAttributedString.Key]
+    ) {
 
     }
 
@@ -244,7 +261,10 @@ open class Attachment: NSTextAttachment, BoundsObserving {
         fatalError("init(coder:) has not been implemented")
     }
 
-    public override func attachmentBounds(for textContainer: NSTextContainer?, proposedLineFragment lineFrag: CGRect, glyphPosition position: CGPoint, characterIndex charIndex: Int) -> CGRect {
+    public override func attachmentBounds(
+        for textContainer: NSTextContainer?, proposedLineFragment lineFrag: CGRect,
+        glyphPosition position: CGPoint, characterIndex charIndex: Int
+    ) -> CGRect {
         guard let textContainer = textContainer else { return .zero }
 
         var size: CGSize
@@ -256,7 +276,8 @@ open class Attachment: NSTextAttachment, BoundsObserving {
         }
 
         if size == .zero,
-            let fittingSize = contentView?.systemLayoutSizeFitting(textContainer.size) {
+            let fittingSize = contentView?.systemLayoutSizeFitting(textContainer.size)
+        {
             size = fittingSize
         }
 
@@ -283,7 +304,9 @@ open class Attachment: NSTextAttachment, BoundsObserving {
             size = CGSize(width: percentWidth, height: size.height)
         }
 
-        let offset = offsetProvider?.offset(for: self, in: textContainer, proposedLineFragment: lineFrag, glyphPosition: position, characterIndex: charIndex) ?? .zero
+        let offset = offsetProvider?.offset(
+            for: self, in: textContainer, proposedLineFragment: lineFrag, glyphPosition: position,
+            characterIndex: charIndex) ?? .zero
 
         self.bounds = CGRect(origin: offset, size: size)
         return self.bounds
@@ -296,7 +319,8 @@ open class Attachment: NSTextAttachment, BoundsObserving {
         self.view.layoutIfNeeded()
 
         if var editorContentView = contentView as? EditorContentView,
-            editorContentView.delegate == nil {
+            editorContentView.delegate == nil
+        {
             editorContentView.delegate = editorView.delegate
         }
     }
@@ -306,7 +330,8 @@ extension Attachment {
     /// Invalidates the current layout and triggers a layout update.
     public func invalidateLayout() {
         guard let editor = containerEditorView,
-            let range = editor.attributedText.rangeFor(attachment: self) else { return }
+            let range = editor.attributedText.rangeFor(attachment: self)
+        else { return }
 
         editor.invalidateLayout(for: range)
         editor.relayoutAttachments()

--- a/Proton/Sources/Attachment/AttachmentSize.swift
+++ b/Proton/Sources/Attachment/AttachmentSize.swift
@@ -6,19 +6,23 @@
 //  Copyright © 2020 Rajdeep Kwatra. All rights reserved.
 //
 
-import Foundation
 import CoreGraphics
+import Foundation
 
 /// Rendering size of the `Attachment`
 public enum AttachmentSize {
     /// Matches the size of the content view of attachment. Content view must provide size to `Attachment` using `didChangeBounds(:)`.
     case matchContent
+
     /// Takes up full width of the containing `EditorView`. Resizes automatically when size of the container changes for e.g. when device is rotated.  Height is dynamic based on content.
     case fullWidth
+
     /// Fixed width attachment irrespective of content size of the contained view. Height is dynamic based on content.
     case fixed(width: CGFloat)
+
     /// Width of attachment is locked between the min and max.  Height is dynamic based on content.
     case range(minWidth: CGFloat, maxWidth: CGFloat)
+
     /// Width in percent based on the size of containing `EditorView`. Absolute value of width changes if the size of the container changes for e.g. when device is rotated.  Height is dynamic based on content.
     case percent(width: CGFloat)
 }

--- a/Proton/Sources/Attachment/SelectionView.swift
+++ b/Proton/Sources/Attachment/SelectionView.swift
@@ -18,13 +18,14 @@ class SelectionView: UIView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
         guard let originalResult = super.hitTest(point, with: event),
-            event?.type == .touches else {
-                return nil
+            event?.type == .touches
+        else {
+            return nil
         }
-        
+
         guard originalResult == self else {
             return originalResult
         }
@@ -38,7 +39,7 @@ class SelectionView: UIView {
         }
         return nil
     }
-    
+
     func addTo(parent: UIView) {
         applyTintColor()
         self.translatesAutoresizingMaskIntoConstraints = false
@@ -50,7 +51,7 @@ class SelectionView: UIView {
             self.trailingAnchor.constraint(equalTo: parent.trailingAnchor),
         ])
     }
-    
+
     private func applyTintColor() {
         // TintColor needs to be picked up from UIButton as it is the only control that
         // provides correct color for macOS accents.

--- a/Proton/Sources/Base/AutogrowingTextView.swift
+++ b/Proton/Sources/Base/AutogrowingTextView.swift
@@ -32,7 +32,7 @@ class AutogrowingTextView: UITextView {
         maxHeightConstraint = heightAnchor.constraint(lessThanOrEqualToConstant: frame.height)
         isScrollEnabled = false
         NSLayoutConstraint.activate([
-            heightAnchor.constraint(greaterThanOrEqualToConstant: frame.height)
+            heightAnchor.constraint(greaterThanOrEqualToConstant: frame.height),
         ])
     }
 
@@ -44,8 +44,10 @@ class AutogrowingTextView: UITextView {
         super.layoutSubviews()
         let bounds = self.bounds
         updateDimensionsCalculatingTextView()
-        let fittingSize = dimensionsCalculatingTextView.sizeThatFits(CGSize(width: frame.width, height: .greatestFiniteMagnitude))
-        isScrollEnabled = (fittingSize.height > bounds.height) || (maxHeight > 0 && maxHeight < fittingSize.height)
+        let fittingSize = dimensionsCalculatingTextView.sizeThatFits(
+            CGSize(width: frame.width, height: .greatestFiniteMagnitude))
+        isScrollEnabled = (fittingSize.height > bounds.height)
+            || (maxHeight > 0 && maxHeight < fittingSize.height)
     }
 
     override open func sizeThatFits(_ size: CGSize) -> CGSize {

--- a/Proton/Sources/Core/RichTextEditorContext.swift
+++ b/Proton/Sources/Core/RichTextEditorContext.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2020 Rajdeep Kwatra. All rights reserved.
 //
 
+import CoreServices
 import Foundation
 import UIKit
-import CoreServices
 
 class RichTextEditorContext: RichTextViewContext {
     static let `default` = RichTextEditorContext()
@@ -16,13 +16,16 @@ class RichTextEditorContext: RichTextViewContext {
     func textViewDidBeginEditing(_ textView: UITextView) {
         activeTextView = textView as? RichTextView
         guard let richTextView = activeTextView else { return }
-        activeTextView?.richTextViewDelegate?.richTextView(richTextView, didReceiveFocusAt: textView.selectedRange)
+        activeTextView?.richTextViewDelegate?.richTextView(
+            richTextView, didReceiveFocusAt: textView.selectedRange)
 
         let range = textView.selectedRange
         var attributes = richTextView.typingAttributes
         let contentType = attributes[.contentType] as? EditorContent.Name ?? .unknown
         attributes[.contentType] = nil
-        richTextView.richTextViewDelegate?.richTextView(richTextView, didChangeSelection: range, attributes: attributes, contentType: contentType)
+        richTextView.richTextViewDelegate?.richTextView(
+            richTextView, didChangeSelection: range, attributes: attributes,
+            contentType: contentType)
     }
 
     func textViewDidEndEditing(_ textView: UITextView) {
@@ -30,19 +33,24 @@ class RichTextEditorContext: RichTextViewContext {
             activeTextView = nil
         }
         guard let richTextView = activeTextView else { return }
-        activeTextView?.richTextViewDelegate?.richTextView(richTextView, didLoseFocusFrom: textView.selectedRange)
+        activeTextView?.richTextViewDelegate?.richTextView(
+            richTextView, didLoseFocusFrom: textView.selectedRange)
     }
 
-    func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+    func textView(
+        _ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String
+    ) -> Bool {
         guard let richTextView = activeTextView else { return true }
 
         let deletedText = textView.attributedText.attributedSubstring(from: range)
-        richTextView.textProcessor?.textStorage(richTextView.textStorage, willProcessDeletedText: deletedText, insertedText: text)
+        richTextView.textProcessor?.textStorage(
+            richTextView.textStorage, willProcessDeletedText: deletedText, insertedText: text)
 
         // if backspace
         var handled = false
         if (text.isEmpty && range.length > 0) || (text.isEmpty && range == .zero) {
-            richTextView.richTextViewDelegate?.richTextView(richTextView, didReceiveKey: .backspace, at: range, handled: &handled)
+            richTextView.richTextViewDelegate?.richTextView(
+                richTextView, didReceiveKey: .backspace, at: range, handled: &handled)
 
             guard handled == false else {
                 return false
@@ -50,9 +58,11 @@ class RichTextEditorContext: RichTextViewContext {
 
             let substring = textView.attributedText.attributedSubstring(from: range)
             guard substring.length > 0,
-                let attachment = substring.attribute(.attachment, at: 0, effectiveRange: nil) as? Attachment,
-                attachment.selectBeforeDelete else {
-                    return true
+                let attachment = substring.attribute(.attachment, at: 0, effectiveRange: nil)
+                    as? Attachment,
+                attachment.selectBeforeDelete
+            else {
+                return true
             }
 
             if attachment.isSelected {
@@ -64,7 +74,8 @@ class RichTextEditorContext: RichTextViewContext {
         }
 
         if text == "\n" {
-            richTextView.richTextViewDelegate?.richTextView(richTextView, didReceiveKey: .enter, at: range, handled: &handled)
+            richTextView.richTextViewDelegate?.richTextView(
+                richTextView, didReceiveKey: .enter, at: range, handled: &handled)
 
             guard handled == false else {
                 return false
@@ -76,6 +87,7 @@ class RichTextEditorContext: RichTextViewContext {
 
     func textViewDidChange(_ textView: UITextView) {
         guard let richTextView = activeTextView else { return }
-        richTextView.richTextViewDelegate?.richTextView(richTextView, didChangeTextAtRange: textView.selectedRange)
+        richTextView.richTextViewDelegate?.richTextView(
+            richTextView, didChangeTextAtRange: textView.selectedRange)
     }
 }

--- a/Proton/Sources/Core/RichTextView.swift
+++ b/Proton/Sources/Core/RichTextView.swift
@@ -30,8 +30,9 @@ class RichTextView: AutogrowingTextView {
     var defaultTypingAttributes: RichTextAttributes {
         return [
             .font: defaultTextFormattingProvider?.font ?? storage.defaultFont,
-            .paragraphStyle: defaultTextFormattingProvider?.paragraphStyle ?? storage.defaultParagraphStyle,
-            .foregroundColor: defaultTextFormattingProvider?.textColor ?? storage.defaultTextColor
+            .paragraphStyle: defaultTextFormattingProvider?.paragraphStyle
+                ?? storage.defaultParagraphStyle,
+            .foregroundColor: defaultTextFormattingProvider?.textColor ?? storage.defaultTextColor,
         ]
     }
 
@@ -86,10 +87,10 @@ class RichTextView: AutogrowingTextView {
     }
 
     #if targetEnvironment(macCatalyst)
-    @objc(_focusRingType)
-    var focusRingType: UInt {
-        return 1 //NSFocusRingTypeNone
-    }
+        @objc(_focusRingType)
+        var focusRingType: UInt {
+            return 1  //NSFocusRingTypeNone
+        }
     #endif
 
     private func setupPlaceholder() {
@@ -100,19 +101,27 @@ class RichTextView: AutogrowingTextView {
         addSubview(placeholderLabel)
         placeholderLabel.attributedText = placeholderText
         NSLayoutConstraint.activate([
-            placeholderLabel.topAnchor.constraint(equalTo: self.topAnchor, constant: textContainerInset.top),
-            placeholderLabel.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -textContainerInset.bottom),
-            placeholderLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: textContainer.lineFragmentPadding),
-            placeholderLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -textContainer.lineFragmentPadding),
-            placeholderLabel.widthAnchor.constraint(equalTo: self.widthAnchor, constant: -textContainer.lineFragmentPadding)
+            placeholderLabel.topAnchor.constraint(
+                equalTo: self.topAnchor, constant: textContainerInset.top),
+            placeholderLabel.bottomAnchor.constraint(
+                equalTo: self.bottomAnchor, constant: -textContainerInset.bottom),
+            placeholderLabel.leadingAnchor.constraint(
+                equalTo: self.leadingAnchor, constant: textContainer.lineFragmentPadding),
+            placeholderLabel.trailingAnchor.constraint(
+                equalTo: self.trailingAnchor, constant: -textContainer.lineFragmentPadding),
+            placeholderLabel.widthAnchor.constraint(
+                equalTo: self.widthAnchor, constant: -textContainer.lineFragmentPadding),
         ])
     }
 
     func wordAt(_ location: Int) -> NSAttributedString? {
         guard let position = self.position(from: beginningOfDocument, offset: location),
-            let wordRange = tokenizer.rangeEnclosingPosition(position, with: .word, inDirection: UITextDirection(rawValue: UITextStorageDirection.backward.rawValue)),
-            let range = wordRange.toNSRange(in: self) else {
-                return nil
+            let wordRange = tokenizer.rangeEnclosingPosition(
+                position, with: .word,
+                inDirection: UITextDirection(rawValue: UITextStorageDirection.backward.rawValue)),
+            let range = wordRange.toNSRange(in: self)
+        else {
+            return nil
         }
         return attributedText.attributedSubstring(from: range)
     }
@@ -128,7 +137,9 @@ class RichTextView: AutogrowingTextView {
         while currentLocation > 0 && layoutManager.isValidGlyphIndex(currentLocation) == false {
             currentLocation -= 1
         }
-        guard layoutManager.isValidGlyphIndex(currentLocation) else { return NSRange(location: 0, length: 1) }
+        guard layoutManager.isValidGlyphIndex(currentLocation) else {
+            return NSRange(location: 0, length: 1)
+        }
         layoutManager.lineFragmentUsedRect(forGlyphAt: currentLocation, effectiveRange: &range)
         guard range.location != NSNotFound else { return nil }
         // As mentioned above, in case of this getting called before layout is completed,
@@ -163,11 +174,14 @@ class RichTextView: AutogrowingTextView {
 
     func edited(range: NSRange) {
         richTextStorage.beginEditing()
-        richTextStorage.edited([.editedCharacters, .editedAttributes], range: range, changeInLength: 0)
+        richTextStorage.edited(
+            [.editedCharacters, .editedAttributes], range: range, changeInLength: 0)
         richTextStorage.endEditing()
     }
 
-    func transformContents<T: EditorContentEncoding>(in range: NSRange? = nil, using transformer: T) -> [T.EncodedType] {
+    func transformContents<T: EditorContentEncoding>(in range: NSRange? = nil, using transformer: T)
+        -> [T.EncodedType]
+    {
         return contents(in: range).compactMap(transformer.encode)
     }
 
@@ -182,17 +196,20 @@ class RichTextView: AutogrowingTextView {
     }
 
     private func updatePlaceholderVisibility() {
-        self.placeholderLabel.attributedText = self.attributedText.length == 0 ? self.placeholderText : NSAttributedString()
+        self.placeholderLabel.attributedText = self.attributedText.length == 0
+            ? self.placeholderText : NSAttributedString()
     }
 
     func attributeValue(at location: CGPoint, for attribute: NSAttributedString.Key) -> Any? {
-        let characterIndex = layoutManager.characterIndex(for: location, in: textContainer, fractionOfDistanceBetweenInsertionPoints: nil)
+        let characterIndex = layoutManager.characterIndex(
+            for: location, in: textContainer, fractionOfDistanceBetweenInsertionPoints: nil)
 
         guard characterIndex < textStorage.length else {
             return nil
         }
 
-        let attributes = textStorage.attributes(at: characterIndex, longestEffectiveRange: nil, in: textStorage.fullRange)
+        let attributes = textStorage.attributes(
+            at: characterIndex, longestEffectiveRange: nil, in: textStorage.fullRange)
         return attributes[attribute]
     }
 
@@ -212,7 +229,11 @@ class RichTextView: AutogrowingTextView {
         storage.removeAttributes(attrs, range: range)
     }
 
-    func enumerateAttribute(_ attrName: NSAttributedString.Key, in enumerationRange: NSRange, options opts: NSAttributedString.EnumerationOptions = [], using block: (Any?, NSRange, UnsafeMutablePointer<ObjCBool>) -> Void) {
+    func enumerateAttribute(
+        _ attrName: NSAttributedString.Key, in enumerationRange: NSRange,
+        options opts: NSAttributedString.EnumerationOptions = [],
+        using block: (Any?, NSRange, UnsafeMutablePointer<ObjCBool>) -> Void
+    ) {
         storage.enumerateAttribute(attrName, in: enumerationRange, options: opts, using: block)
     }
 
@@ -229,12 +250,16 @@ class RichTextView: AutogrowingTextView {
 
     func didTap(at location: CGPoint) {
         let characterRange = rangeOfCharacter(at: location)
-        richTextViewDelegate?.richTextView(self, didTapAtLocation: location, characterRange: characterRange)
+        richTextViewDelegate?.richTextView(
+            self, didTapAtLocation: location, characterRange: characterRange)
     }
 }
 
 extension RichTextView: NSLayoutManagerDelegate {
-    func layoutManager(_ layoutManager: NSLayoutManager, didCompleteLayoutFor textContainer: NSTextContainer?, atEnd layoutFinishedFlag: Bool) {
+    func layoutManager(
+        _ layoutManager: NSLayoutManager, didCompleteLayoutFor textContainer: NSTextContainer?,
+        atEnd layoutFinishedFlag: Bool
+    ) {
         updatePlaceholderVisibility()
         richTextViewDelegate?.richTextView(self, didFinishLayout: layoutFinishedFlag)
     }

--- a/Proton/Sources/Core/RichTextViewContext.swift
+++ b/Proton/Sources/Core/RichTextViewContext.swift
@@ -12,7 +12,10 @@ import UIKit
 class RichTextViewContext: NSObject, UITextViewDelegate {
     var activeTextView: RichTextView?
 
-    func textView(_ textView: UITextView, shouldInteractWith textAttachment: NSTextAttachment, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
+    func textView(
+        _ textView: UITextView, shouldInteractWith textAttachment: NSTextAttachment,
+        in characterRange: NSRange, interaction: UITextItemInteraction
+    ) -> Bool {
         return interaction != .presentActions
     }
 
@@ -27,14 +30,18 @@ class RichTextViewContext: NSObject, UITextViewDelegate {
             var attributes = richTextView.typingAttributes
             let contentType = attributes[.contentType] as? EditorContent.Name ?? .unknown
             attributes[.contentType] = nil
-            richTextView.richTextViewDelegate?.richTextView(richTextView, didChangeSelection: range, attributes: attributes, contentType: contentType)
+            richTextView.richTextViewDelegate?.richTextView(
+                richTextView, didChangeSelection: range, attributes: attributes,
+                contentType: contentType)
             return
         }
 
         let substring = textView.attributedText.attributedSubstring(from: range)
 
         // Mark attachments as selected if there are any in the selected range
-        substring.enumerateAttribute(.attachment, in: substring.fullRange, options: .longestEffectiveRangeNotRequired) { attachment, range, _ in
+        substring.enumerateAttribute(
+            .attachment, in: substring.fullRange, options: .longestEffectiveRangeNotRequired
+        ) { attachment, range, _ in
             if let attachment = attachment as? Attachment {
                 attachment.isSelected = true
             }
@@ -43,12 +50,16 @@ class RichTextViewContext: NSObject, UITextViewDelegate {
         var attributes = substring.attributes(at: 0, effectiveRange: nil)
         let contentType = attributes[.contentType] as? EditorContent.Name ?? .unknown
         attributes[.contentType] = nil
-        richTextView.richTextViewDelegate?.richTextView(richTextView, didChangeSelection: range, attributes: attributes, contentType: contentType)
+        richTextView.richTextViewDelegate?.richTextView(
+            richTextView, didChangeSelection: range, attributes: attributes,
+            contentType: contentType)
     }
 
     func resetAttachmentSelection(_ textView: UITextView) {
         guard let attributedText = textView.attributedText else { return }
-        attributedText.enumerateAttribute(.attachment, in: attributedText.fullRange, options: .longestEffectiveRangeNotRequired) { attachment, _, _ in
+        attributedText.enumerateAttribute(
+            .attachment, in: attributedText.fullRange, options: .longestEffectiveRangeNotRequired
+        ) { attachment, _, _ in
             if let attachment = attachment as? Attachment {
                 attachment.isSelected = false
             }

--- a/Proton/Sources/Core/RichTextViewDelegate.swift
+++ b/Proton/Sources/Core/RichTextViewDelegate.swift
@@ -15,11 +15,22 @@ public enum EditorKey {
 }
 
 protocol RichTextViewDelegate: AnyObject {
-    func richTextView(_ richTextView: RichTextView, didChangeSelection range: NSRange, attributes: [NSAttributedString.Key: Any], contentType: EditorContent.Name)
-    func richTextView(_ richTextView: RichTextView, didReceiveKey key: EditorKey, at range: NSRange, handled: inout Bool)
+    func richTextView(
+        _ richTextView: RichTextView, didChangeSelection range: NSRange,
+        attributes: [NSAttributedString.Key: Any], contentType: EditorContent.Name
+    )
+
+    func richTextView(
+        _ richTextView: RichTextView, didReceiveKey key: EditorKey, at range: NSRange,
+        handled: inout Bool
+    )
+
     func richTextView(_ richTextView: RichTextView, didReceiveFocusAt range: NSRange)
     func richTextView(_ richTextView: RichTextView, didLoseFocusFrom range: NSRange)
     func richTextView(_ richTextView: RichTextView, didFinishLayout finished: Bool)
     func richTextView(_ richTextView: RichTextView, didChangeTextAtRange range: NSRange)
-    func richTextView(_ richTextView: RichTextView, didTapAtLocation location: CGPoint, characterRange: NSRange?)
+
+    func richTextView(
+        _ richTextView: RichTextView, didTapAtLocation location: CGPoint, characterRange: NSRange?
+    )
 }

--- a/Proton/Sources/Core/TextStorage.swift
+++ b/Proton/Sources/Core/TextStorage.swift
@@ -38,7 +38,9 @@ class TextStorage: NSTextStorage {
         storage.setAttributedString(attributedString)
     }
 
-    @available(*, unavailable, message: "init(itemProviderData:typeIdentifier:) unavailable, use init")
+    @available(
+        *, unavailable, message: "init(itemProviderData:typeIdentifier:) unavailable, use init"
+    )
     required init(itemProviderData data: Data, typeIdentifier: String) throws {
         fatalError("init(itemProviderData:typeIdentifier:) has not been implemented")
     }
@@ -52,7 +54,9 @@ class TextStorage: NSTextStorage {
         return storage.string
     }
 
-    override func attributes(at location: Int, effectiveRange range: NSRangePointer?) -> [NSAttributedString.Key: Any] {
+    override func attributes(at location: Int, effectiveRange range: NSRangePointer?)
+        -> [NSAttributedString.Key: Any]
+    {
         guard storage.length > location else {
             return [:]
         }
@@ -81,16 +85,21 @@ class TextStorage: NSTextStorage {
         let updatedAttributes = applyingDefaultFormattingIfRequired(attrs)
         storage.setAttributes(updatedAttributes, range: range)
         storage.rangesOf(characterSet: .newlines)
-            .forEach { storage.addAttribute(.contentType, value: EditorContent.Name.newline, range: $0) }
+            .forEach {
+                storage.addAttribute(.contentType, value: EditorContent.Name.newline, range: $0)
+            }
         storage.fixAttributes(in: NSRange(location: 0, length: storage.length))
         edited([.editedAttributes], range: range, changeInLength: 0)
         endEditing()
     }
 
-    private func applyingDefaultFormattingIfRequired(_ attributes: RichTextAttributes?) -> RichTextAttributes {
+    private func applyingDefaultFormattingIfRequired(_ attributes: RichTextAttributes?)
+        -> RichTextAttributes
+    {
         var updatedAttributes = attributes ?? [:]
         if attributes?[.paragraphStyle] == nil {
-            updatedAttributes[.paragraphStyle] = defaultTextFormattingProvider?.paragraphStyle ?? defaultParagraphStyle
+            updatedAttributes[.paragraphStyle] = defaultTextFormattingProvider?.paragraphStyle
+                ?? defaultParagraphStyle
         }
 
         if attributes?[.font] == nil {
@@ -98,7 +107,8 @@ class TextStorage: NSTextStorage {
         }
 
         if attributes?[.foregroundColor] == nil {
-            updatedAttributes[.foregroundColor] = defaultTextFormattingProvider?.textColor ?? defaultTextColor
+            updatedAttributes[.foregroundColor] = defaultTextFormattingProvider?.textColor
+                ?? defaultTextColor
         }
 
         return updatedAttributes
@@ -121,7 +131,9 @@ class TextStorage: NSTextStorage {
         endEditing()
     }
 
-    private func fixMissingAttributes(deletedAttributes attrs: [NSAttributedString.Key], range: NSRange) {
+    private func fixMissingAttributes(
+        deletedAttributes attrs: [NSAttributedString.Key], range: NSRange
+    ) {
         if attrs.contains(.foregroundColor) {
             storage.addAttribute(.foregroundColor, value: defaultTextColor, range: range)
         }
@@ -143,27 +155,33 @@ class TextStorage: NSTextStorage {
         let spacer = attachment.spacer.string
         var hasPrevSpacer = false
         if range.length + range.location > 0 {
-            hasPrevSpacer = attributedSubstring(from: NSRange(location: max(range.location - 1, 0), length: 1)).string == spacer
+            hasPrevSpacer =
+                attributedSubstring(from: NSRange(location: max(range.location - 1, 0), length: 1))
+                .string == spacer
         }
         var hasNextSpacer = false
         if (range.location + range.length + 1) <= length {
-            hasNextSpacer = attributedSubstring(from: NSRange(location: range.location, length: 1)).string == spacer
+            hasNextSpacer =
+                attributedSubstring(from: NSRange(location: range.location, length: 1)).string
+                == spacer
         }
 
-        let attachmentString = attachment.stringWithSpacers(appendPrev: !hasPrevSpacer, appendNext: !hasNextSpacer)
+        let attachmentString = attachment.stringWithSpacers(
+            appendPrev: !hasPrevSpacer, appendNext: !hasNextSpacer)
         replaceCharacters(in: range, with: attachmentString)
     }
 
     private func getAttachments(in range: NSRange) -> [Attachment] {
         var attachments = [Attachment]()
-        storage.enumerateAttribute(.attachment,
-                                   in: range,
-                                   options: .longestEffectiveRangeNotRequired,
-                                   using: { (attribute, _, _) in
-                                    if let attachment = attribute as? Attachment {
-                                        attachments.append(attachment)
-                                    }
-        })
+        storage.enumerateAttribute(
+            .attachment,
+            in: range,
+            options: .longestEffectiveRangeNotRequired,
+            using: { (attribute, _, _) in
+                if let attachment = attribute as? Attachment {
+                    attachments.append(attachment)
+                }
+            })
         return attachments
     }
 }

--- a/Proton/Sources/Decoding/EditorContentDecoding.swift
+++ b/Proton/Sources/Decoding/EditorContentDecoding.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2020 Rajdeep Kwatra. All rights reserved.
 //
 
+import CoreServices
 import Foundation
 import UIKit
-import CoreServices
 
 /// Content mode for `Editor`. This may be used while decoding the content for the Editor/Renderer to let the Decoder know
 /// which mode the content is being decoded for. For e.g. you may  want to have different decoded value based on whether the
@@ -44,7 +44,7 @@ public struct AnyEditorContentDecoding<T>: EditorContentDecoding {
         decoding = decoder.decode
     }
 
-   /// Decodes the given value to `NSAttributedString`
+    /// Decodes the given value to `NSAttributedString`
     /// - Parameters:
     ///   - mode: Mode for decoding
     ///   - maxSize: Maximum available size of the container in which the content will be rendered.

--- a/Proton/Sources/Editor/EditorContent.swift
+++ b/Proton/Sources/Editor/EditorContent.swift
@@ -42,8 +42,8 @@ public struct EditorContent {
     }
 }
 
-public extension EditorContent {
-    struct Name: Hashable, Equatable, RawRepresentable {
+extension EditorContent {
+    public struct Name: Hashable, Equatable, RawRepresentable {
         public var rawValue: String
 
         public static let paragraph = Name("paragraph")

--- a/Proton/Sources/Editor/EditorContentIdentifying.swift
+++ b/Proton/Sources/Editor/EditorContentIdentifying.swift
@@ -17,6 +17,6 @@ public protocol EditorContentIdentifying {
 // Convenience type for a UIView that can be placed within the Editor as the content of an `Attachment`
 typealias AttachmentView = UIView & EditorContentIdentifying
 
-public protocol BlockContent: EditorContentIdentifying { }
+public protocol BlockContent: EditorContentIdentifying {}
 
-public protocol InlineContent: EditorContentIdentifying { }
+public protocol InlineContent: EditorContentIdentifying {}

--- a/Proton/Sources/Editor/EditorContentView.swift
+++ b/Proton/Sources/Editor/EditorContentView.swift
@@ -20,32 +20,32 @@ public protocol EditorContentView: Focusable {
     func becomeFirstResponder() -> Bool
 }
 
-public extension EditorContentView {
-    var attributedText: NSAttributedString {
+extension EditorContentView {
+    public var attributedText: NSAttributedString {
         get { editor.attributedText }
         set { editor.attributedText = newValue }
     }
 
-    func becomeFirstResponder() -> Bool {
+    public func becomeFirstResponder() -> Bool {
         return editor.becomeFirstResponder()
     }
 
-    var maxHeight: CGFloat {
+    public var maxHeight: CGFloat {
         get { editor.maxHeight }
         set { editor.maxHeight = newValue }
     }
 
-    var boundsObserver: BoundsObserving? {
+    public var boundsObserver: BoundsObserving? {
         get { editor.boundsObserver }
         set { editor.boundsObserver = newValue }
     }
 
-    var delegate: EditorViewDelegate? {
+    public var delegate: EditorViewDelegate? {
         get { editor.delegate }
         set { editor.delegate = newValue }
     }
 
-    func setFocus() {
+    public func setFocus() {
         editor.becomeFirstResponder()
     }
 }

--- a/Proton/Sources/Editor/EditorView.swift
+++ b/Proton/Sources/Editor/EditorView.swift
@@ -85,6 +85,7 @@ open class EditorView: UIView {
 
     /// An object interested in responding to editing and focus related events in the `EditorView`.
     public weak var delegate: EditorViewDelegate?
+
     var textProcessor: TextProcessor?
 
     /// List of commands supported by the editor.
@@ -201,17 +202,17 @@ open class EditorView: UIView {
     /// Current line information based the caret position or selected range. If the selected range spans across multiple
     /// lines, only the line information of the line containing the start of the range is returned.
     public var currentLine: EditorLine? {
-        return editorLineFrom(range: richTextView.currentLineRange )
+        return editorLineFrom(range: richTextView.currentLineRange)
     }
 
     /// First line of content in the Editor. Nil if editor is empty.
     public var firstLine: EditorLine? {
-        return editorLineFrom(range: NSRange(location: 1, length: 0) )
+        return editorLineFrom(range: NSRange(location: 1, length: 0))
     }
 
     /// Last line of content in the Editor. Nil if editor is empty.
     public var lastLine: EditorLine? {
-        return editorLineFrom(range: NSRange(location: contentLength - 1, length: 0) )
+        return editorLineFrom(range: NSRange(location: contentLength - 1, length: 0))
     }
 
     /// Selected text in the editor.
@@ -369,7 +370,7 @@ open class EditorView: UIView {
 
         typingAttributes = [
             .font: font,
-            .paragraphStyle: paragraphStyle
+            .paragraphStyle: paragraphStyle,
         ]
         richTextView.adjustsFontForContentSizeCategory = true
     }
@@ -396,7 +397,8 @@ open class EditorView: UIView {
     /// `EditorLine` after the given line. Nil if the Editor is empty or given line is last line in the Editor.
     public func lineAfter(_ line: EditorLine) -> EditorLine? {
         let lineRange = line.range
-        let nextLineStartRange = NSRange(location: lineRange.location + lineRange.length + 1, length: 0)
+        let nextLineStartRange = NSRange(
+            location: lineRange.location + lineRange.length + 1, length: 0)
         guard nextLineStartRange.isValidIn(richTextView) else { return nil }
         return editorLineFrom(range: nextLineStartRange)
     }
@@ -414,7 +416,8 @@ open class EditorView: UIView {
 
     private func editorLineFrom(range: NSRange?) -> EditorLine? {
         guard let range = range,
-            let lineRange = richTextView.lineRange(from: range.location) else { return nil }
+            let lineRange = richTextView.lineRange(from: range.location)
+        else { return nil }
 
         let text = attributedText.attributedSubstring(from: lineRange)
         return EditorLine(text: text, range: lineRange)
@@ -439,7 +442,8 @@ open class EditorView: UIView {
     /// - Returns:
     /// Rectangle for caret based on the line height and given location.
     public func caretRect(for position: Int) -> CGRect {
-        let textPosition = richTextView.position(from: richTextView.beginningOfDocument, offset: position) ?? richTextView.endOfDocument
+        let textPosition = richTextView.position(
+            from: richTextView.beginningOfDocument, offset: position) ?? richTextView.endOfDocument
         return richTextView.caretRect(for: textPosition)
     }
 
@@ -497,7 +501,9 @@ open class EditorView: UIView {
     /// - Parameter transformer: Transformer capable of transforming `EditorContent` to given type
     /// - Returns:
     /// Array of transformed contents based on given transformer.
-    public func transformContents<T: EditorContentEncoding>(in range: NSRange? = nil, using transformer: T) -> [T.EncodedType] {
+    public func transformContents<T: EditorContentEncoding>(
+        in range: NSRange? = nil, using transformer: T
+    ) -> [T.EncodedType] {
         return richTextView.transformContents(in: range, using: transformer)
     }
 
@@ -517,11 +523,13 @@ open class EditorView: UIView {
     /// - Parameter range: Range of text to replace. For an empty `EditorView`, you may pass `NSRange.zero` to insert text at the beginning.
     /// - Parameter string: String to replace the range of text with. The string will use default `font` and `paragraphStyle` defined in the `EditorView`.
     public func replaceCharacters(in range: NSRange, with string: String) {
-        let attributedString = NSAttributedString(string: string, attributes: [
-            .paragraphStyle: paragraphStyle,
-            .font: font,
-            .foregroundColor: textColor
-        ])
+        let attributedString = NSAttributedString(
+            string: string,
+            attributes: [
+                .paragraphStyle: paragraphStyle,
+                .font: font,
+                .foregroundColor: textColor,
+            ])
         richTextView.replaceCharacters(in: range, with: attributedString)
     }
 
@@ -603,9 +611,12 @@ extension EditorView {
     ///   - range: Range on which attributes should be applied to.
     public func addAttributes(_ attributes: [NSAttributedString.Key: Any], at range: NSRange) {
         self.richTextView.addAttributes(attributes, range: range)
-        self.richTextView.enumerateAttribute(.attachment, in: range, options: .longestEffectiveRangeNotRequired) { value, rangeInContainer, _ in
+        self.richTextView.enumerateAttribute(
+            .attachment, in: range, options: .longestEffectiveRangeNotRequired
+        ) { value, rangeInContainer, _ in
             if let attachment = value as? Attachment {
-                attachment.addedAttributesOnContainingRange(rangeInContainer: rangeInContainer, attributes: attributes)
+                attachment.addedAttributesOnContainingRange(
+                    rangeInContainer: rangeInContainer, attributes: attributes)
             }
         }
     }
@@ -616,9 +627,12 @@ extension EditorView {
     ///   - range: Range to remove the attributes from.
     public func removeAttributes(_ attributes: [NSAttributedString.Key], at range: NSRange) {
         self.richTextView.removeAttributes(attributes, range: range)
-        self.richTextView.enumerateAttribute(.attachment, in: range, options: .longestEffectiveRangeNotRequired) { value, rangeInContainer, _ in
+        self.richTextView.enumerateAttribute(
+            .attachment, in: range, options: .longestEffectiveRangeNotRequired
+        ) { value, rangeInContainer, _ in
             if let attachment = value as? Attachment {
-                attachment.removedAttributesFromContainingRange(rangeInContainer: rangeInContainer, attributes: attributes)
+                attachment.removedAttributesFromContainingRange(
+                    rangeInContainer: rangeInContainer, attributes: attributes)
             }
         }
     }
@@ -641,14 +655,21 @@ extension EditorView {
     }
 }
 
-extension EditorView: DefaultTextFormattingProviding { }
+extension EditorView: DefaultTextFormattingProviding {}
 
 extension EditorView: RichTextViewDelegate {
-    func richTextView(_ richTextView: RichTextView, didChangeSelection range: NSRange, attributes: [NSAttributedString.Key: Any], contentType: EditorContent.Name) {
-        delegate?.editor(self, didChangeSelectionAt: range, attributes: attributes, contentType: contentType)
+    func richTextView(
+        _ richTextView: RichTextView, didChangeSelection range: NSRange,
+        attributes: [NSAttributedString.Key: Any], contentType: EditorContent.Name
+    ) {
+        delegate?.editor(
+            self, didChangeSelectionAt: range, attributes: attributes, contentType: contentType)
     }
 
-    func richTextView(_ richTextView: RichTextView, didReceiveKey key: EditorKey, at range: NSRange, handled: inout Bool) {
+    func richTextView(
+        _ richTextView: RichTextView, didReceiveKey key: EditorKey, at range: NSRange,
+        handled: inout Bool
+    ) {
         delegate?.editor(self, didReceiveKey: key, at: range, handled: &handled)
     }
 
@@ -669,7 +690,9 @@ extension EditorView: RichTextViewDelegate {
         relayoutAttachments()
     }
 
-    func richTextView(_ richTextView: RichTextView, didTapAtLocation location: CGPoint, characterRange: NSRange?) { }
+    func richTextView(
+        _ richTextView: RichTextView, didTapAtLocation location: CGPoint, characterRange: NSRange?
+    ) {}
 }
 
 extension EditorView {
@@ -678,7 +701,10 @@ extension EditorView {
     }
 
     func relayoutAttachments() {
-        richTextView.enumerateAttribute(.attachment, in: NSRange(location: 0, length: richTextView.contentLength), options: .longestEffectiveRangeNotRequired) { (attach, range, _) in
+        richTextView.enumerateAttribute(
+            .attachment, in: NSRange(location: 0, length: richTextView.contentLength),
+            options: .longestEffectiveRangeNotRequired
+        ) { (attach, range, _) in
             guard let attachment = attach as? Attachment else { return }
 
             // Remove attachment from container if it is already added to another Editor
@@ -692,7 +718,8 @@ extension EditorView {
 
             var size = attachment.frame.size
             if size == .zero,
-                let contentSize = attachment.contentView?.systemLayoutSizeFitting(bounds.size) {
+                let contentSize = attachment.contentView?.systemLayoutSizeFitting(bounds.size)
+            {
                 size = contentSize
             }
 
@@ -709,11 +736,11 @@ extension EditorView {
     }
 }
 
-public extension EditorView {
+extension EditorView {
     /// Creates a `RendererView` from current `EditorView`
     /// - Returns:
     /// `RendererView` for the Editor
-    func convertToRenderer() -> RendererView {
+    public func convertToRenderer() -> RendererView {
         return RendererView(editor: self)
     }
 
@@ -722,7 +749,7 @@ public extension EditorView {
     /// - Parameter command: Command to validate
     /// - Returns:
     /// `true` if the command is registered with the Editor.
-    func isCommandRegistered(_ command: EditorCommand) -> Bool {
+    public func isCommandRegistered(_ command: EditorCommand) -> Bool {
         return registeredCommands?.contains { $0 === command } ?? true
     }
 }

--- a/Proton/Sources/Editor/EditorViewDelegate.swift
+++ b/Proton/Sources/Editor/EditorViewDelegate.swift
@@ -9,17 +9,31 @@
 import Foundation
 
 public protocol EditorViewDelegate: AnyObject {
-    func editor(_ editor: EditorView, didReceiveKey key: EditorKey, at range: NSRange, handled: inout Bool)
+    func editor(
+        _ editor: EditorView, didReceiveKey key: EditorKey, at range: NSRange, handled: inout Bool
+    )
+
     func editor(_ editor: EditorView, didReceiveFocusAt range: NSRange)
     func editor(_ editor: EditorView, didLoseFocusFrom range: NSRange)
     func editor(_ editor: EditorView, didChangeTextAt range: NSRange)
-    func editor(_ editor: EditorView, didChangeSelectionAt range: NSRange, attributes: [NSAttributedString.Key: Any], contentType: EditorContent.Name)
+
+    func editor(
+        _ editor: EditorView, didChangeSelectionAt range: NSRange,
+        attributes: [NSAttributedString.Key: Any], contentType: EditorContent.Name
+    )
 }
 
-public extension EditorViewDelegate {
-    func editor(_ editor: EditorView, didReceiveKey key: EditorKey, at range: NSRange, handled: inout Bool) { }
-    func editor(_ editor: EditorView, didReceiveFocusAt range: NSRange) { }
-    func editor(_ editor: EditorView, didLoseFocusFrom range: NSRange) { }
-    func editor(_ editor: EditorView, didChangeTextAt range: NSRange) { }
-    func editor(_ editor: EditorView, didChangeSelectionAt range: NSRange, attributes: [NSAttributedString.Key: Any], contentType: EditorContent.Name) { }
+extension EditorViewDelegate {
+    public func editor(
+        _ editor: EditorView, didReceiveKey key: EditorKey, at range: NSRange, handled: inout Bool
+    ) {}
+
+    public func editor(_ editor: EditorView, didReceiveFocusAt range: NSRange) {}
+    public func editor(_ editor: EditorView, didLoseFocusFrom range: NSRange) {}
+    public func editor(_ editor: EditorView, didChangeTextAt range: NSRange) {}
+
+    public func editor(
+        _ editor: EditorView, didChangeSelectionAt range: NSRange,
+        attributes: [NSAttributedString.Key: Any], contentType: EditorContent.Name
+    ) {}
 }

--- a/Proton/Sources/EditorCommand/EditorCommand.swift
+++ b/Proton/Sources/EditorCommand/EditorCommand.swift
@@ -24,8 +24,8 @@ public protocol EditorCommand: AnyObject {
     func execute(on editor: EditorView)
 }
 
-public extension EditorCommand {
-    func canExecute(on editor: EditorView) -> Bool {
+extension EditorCommand {
+    public func canExecute(on editor: EditorView) -> Bool {
         return editor.registeredCommands?.contains { $0 === self } ?? true
     }
 }

--- a/Proton/Sources/EditorCommand/EditorCommandExecutor.swift
+++ b/Proton/Sources/EditorCommand/EditorCommandExecutor.swift
@@ -28,7 +28,8 @@ public class EditorCommandExecutor {
         guard let activeEditor = context.activeTextView,
             let editor = activeEditor.superview as? EditorView,
             editor.isCommandRegistered(command),
-            command.canExecute(on: editor) else { return }
+            command.canExecute(on: editor)
+        else { return }
         command.execute(on: editor)
     }
 }

--- a/Proton/Sources/EditorCommand/FontTraitToggleCommand.swift
+++ b/Proton/Sources/EditorCommand/FontTraitToggleCommand.swift
@@ -25,18 +25,25 @@ public class FontTraitToggleCommand: EditorCommand {
         }
 
         if selectedText.length == 0 {
-            guard let font = editor.attributedText.attribute(.font, at: editor.selectedRange.location - 1, effectiveRange: nil) as? UIFont else { return }
+            guard
+                let font = editor.attributedText.attribute(
+                    .font, at: editor.selectedRange.location - 1, effectiveRange: nil) as? UIFont
+            else { return }
             editor.typingAttributes[.font] = font.toggled(trait: trait)
             return
         }
 
-        guard let initFont = selectedText.attribute(.font, at: 0, effectiveRange: nil) as? UIFont else {
+        guard let initFont = selectedText.attribute(.font, at: 0, effectiveRange: nil) as? UIFont
+        else {
             return
         }
 
-        editor.attributedText.enumerateAttribute(.font, in: editor.selectedRange, options: .longestEffectiveRangeNotRequired) { font, range, _ in
+        editor.attributedText.enumerateAttribute(
+            .font, in: editor.selectedRange, options: .longestEffectiveRangeNotRequired
+        ) { font, range, _ in
             if let font = font as? UIFont {
-                let fontToApply = initFont.contains(trait: trait) ? font.removing(trait: trait) : font.adding(trait: trait)
+                let fontToApply = initFont.contains(trait: trait)
+                    ? font.removing(trait: trait) : font.adding(trait: trait)
                 editor.addAttribute(.font, value: fontToApply, at: range)
             }
         }

--- a/Proton/Sources/Encoding/EditorContentEncoding.swift
+++ b/Proton/Sources/Encoding/EditorContentEncoding.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2020 Rajdeep Kwatra. All rights reserved.
 //
 
+import CoreServices
 import Foundation
 import UIKit
-import CoreServices
 
 /// An object capable of encoding `EditorContent` to given type.
 public protocol EditorContentEncoding {
@@ -55,8 +55,8 @@ public protocol EditorContentEncoder: EditorContentEncoding {
     func encode(_ content: EditorContent) -> T!
 }
 
-public extension EditorContentEncoder {
-    func encode(_ content: EditorContent) -> T! {
+extension EditorContentEncoder {
+    public func encode(_ content: EditorContent) -> T! {
         switch content.type {
         case .viewOnly:
             return nil
@@ -64,7 +64,7 @@ public extension EditorContentEncoder {
             guard let encodable = attachmentEncoders[name] else { return nil }
             return encodable.encode(name: name, view: contentView)
         case let .text(name, attributedString):
-            guard let encodable = textEncoders[name] else {  return nil }
+            guard let encodable = textEncoders[name] else { return nil }
             return encodable.encode(name: name, string: attributedString)
         }
     }

--- a/Proton/Sources/Helpers/NSAttributedString+Range.swift
+++ b/Proton/Sources/Helpers/NSAttributedString+Range.swift
@@ -9,12 +9,12 @@
 import Foundation
 import UIKit
 
-public extension NSAttributedString {
-    var fullRange: NSRange {
+extension NSAttributedString {
+    public var fullRange: NSRange {
         return NSRange(location: 0, length: length)
     }
 
-    var attachmentRanges: [(attachment: Attachment, range: NSRange)] {
+    public var attachmentRanges: [(attachment: Attachment, range: NSRange)] {
         var ranges = [(Attachment, NSRange)]()
 
         let fullRange = NSRange(location: 0, length: self.length)
@@ -26,18 +26,19 @@ public extension NSAttributedString {
         return ranges
     }
 
-    func rangeFor(attachment: Attachment) -> NSRange? {
+    public func rangeFor(attachment: Attachment) -> NSRange? {
         return attachmentRanges.reversed().first(where: { $0.attachment == attachment })?.range
     }
 
-    func rangesOf(characterSet: CharacterSet) -> [NSRange] {
+    public func rangesOf(characterSet: CharacterSet) -> [NSRange] {
         return string.rangesOf(characterSet: characterSet).map { string.makeNSRange(from: $0) }
     }
 
-    func reverseAttributedSubstring(from range: NSRange) -> NSAttributedString? {
+    public func reverseAttributedSubstring(from range: NSRange) -> NSAttributedString? {
         guard length > 0 && range.location + range.length < length else {
             return nil
         }
-        return attributedSubstring(from: NSRange(location: range.location - range.length, length: range.length))
+        return attributedSubstring(
+            from: NSRange(location: range.location - range.length, length: range.length))
     }
 }

--- a/Proton/Sources/Helpers/NSRangeExtensions.swift
+++ b/Proton/Sources/Helpers/NSRangeExtensions.swift
@@ -9,35 +9,39 @@
 import Foundation
 import UIKit
 
-public extension NSRange {
-    static var zero: NSRange {
+extension NSRange {
+    public static var zero: NSRange {
         return NSRange(location: 0, length: 0)
     }
 
-    var firstCharacterRange: NSRange {
+    public var firstCharacterRange: NSRange {
         return NSRange(location: location, length: 1)
     }
 
-    var lastCharacterRange: NSRange {
+    public var lastCharacterRange: NSRange {
         return NSRange(location: location + length, length: 1)
     }
 
-    var nextPosition: NSRange {
+    public var nextPosition: NSRange {
         return NSRange(location: location + 1, length: 0)
     }
 
-    func toTextRange(textInput: UITextInput) -> UITextRange? {
-        guard let rangeStart = textInput.position(from: textInput.beginningOfDocument, offset: location),
-            let rangeEnd = textInput.position(from: rangeStart, offset: length) else {
-                return nil
+    public func toTextRange(textInput: UITextInput) -> UITextRange? {
+        guard
+            let rangeStart = textInput.position(
+                from: textInput.beginningOfDocument, offset: location),
+            let rangeEnd = textInput.position(from: rangeStart, offset: length)
+        else {
+            return nil
         }
         return textInput.textRange(from: rangeStart, to: rangeEnd)
     }
 
-    func isValidIn(_ textInput: UITextInput) -> Bool {
+    public func isValidIn(_ textInput: UITextInput) -> Bool {
         guard location > 0 else { return false }
         let end = location + length
-        let contentLength = textInput.offset(from: textInput.beginningOfDocument, to: textInput.endOfDocument)
+        let contentLength = textInput.offset(
+            from: textInput.beginningOfDocument, to: textInput.endOfDocument)
         return end < contentLength
     }
 }

--- a/Proton/Sources/Helpers/String+NSRange.swift
+++ b/Proton/Sources/Helpers/String+NSRange.swift
@@ -8,36 +8,42 @@
 
 import Foundation
 
-public extension String {
-    func makeNSRange(from range: Range<String.Index>) -> NSRange {
-        let range = range.lowerBound ..< min(range.upperBound, endIndex)
+extension String {
+    public func makeNSRange(from range: Range<String.Index>) -> NSRange {
+        let range = range.lowerBound..<min(range.upperBound, endIndex)
 
         guard let from = range.lowerBound.samePosition(in: utf16),
-            let to = range.upperBound.samePosition(in: utf16) else {
-                return NSRange(location: NSNotFound, length: 0)
+            let to = range.upperBound.samePosition(in: utf16)
+        else {
+            return NSRange(location: NSNotFound, length: 0)
         }
 
-        return NSRange(location: utf16.distance(from: utf16.startIndex, to: from),
-                       length: utf16.distance(from: from, to: to))
+        return NSRange(
+            location: utf16.distance(from: utf16.startIndex, to: from),
+            length: utf16.distance(from: from, to: to))
     }
 
-    func rangeFromNSRange(range: NSRange) -> Range<String.Index>? {
+    public func rangeFromNSRange(range: NSRange) -> Range<String.Index>? {
         guard
-            let from16 = utf16.index(utf16.startIndex, offsetBy: range.location, limitedBy: utf16.endIndex),
-            let to16 = utf16.index(utf16.startIndex, offsetBy: range.location + range.length, limitedBy: utf16.endIndex),
+            let from16 = utf16.index(
+                utf16.startIndex, offsetBy: range.location, limitedBy: utf16.endIndex),
+            let to16 = utf16.index(
+                utf16.startIndex, offsetBy: range.location + range.length, limitedBy: utf16.endIndex
+            ),
             let from = from16.samePosition(in: self),
             let to = to16.samePosition(in: self)
-            else { return nil }
-        return from ..< to
+        else { return nil }
+        return from..<to
     }
 
-    func rangesOf(characterSet: CharacterSet) -> [Range<String.Index>] {
+    public func rangesOf(characterSet: CharacterSet) -> [Range<String.Index>] {
         var ranges = [Range<String.Index>]()
         var newlineRange = rangeOfCharacter(from: .newlines, options: [], range: nil)
         while newlineRange != nil {
             guard let range = newlineRange else { break }
             ranges.append(range)
-            newlineRange = rangeOfCharacter(from: .newlines, options: [], range: range.upperBound ..< endIndex)
+            newlineRange = rangeOfCharacter(
+                from: .newlines, options: [], range: range.upperBound..<endIndex)
         }
         return ranges
     }

--- a/Proton/Sources/Helpers/Text/FontExtensions.swift
+++ b/Proton/Sources/Helpers/Text/FontExtensions.swift
@@ -9,40 +9,40 @@
 import Foundation
 import UIKit
 
-public extension UIFont {
+extension UIFont {
 
-    var traits: UIFontDescriptor.SymbolicTraits {
+    public var traits: UIFontDescriptor.SymbolicTraits {
         return fontDescriptor.symbolicTraits
     }
 
-    var isBold: Bool {
+    public var isBold: Bool {
         return traits.contains(.traitBold)
     }
 
-    var isItalics: Bool {
+    public var isItalics: Bool {
         return traits.contains(.traitItalic)
     }
 
-    var isMonoSpaced: Bool {
+    public var isMonoSpaced: Bool {
         return traits.contains(.traitMonoSpace)
     }
 
-    var textStyle: UIFont.TextStyle {
+    public var textStyle: UIFont.TextStyle {
         guard let style = fontDescriptor.object(forKey: .textStyle) as? String else {
             return .body
         }
         return UIFont.TextStyle(rawValue: style)
     }
 
-    var isNonDynamicTextStyle: Bool {
+    public var isNonDynamicTextStyle: Bool {
         return textStyle.rawValue == "CTFontRegularUsage"
     }
 
-    func contains(trait: UIFontDescriptor.SymbolicTraits) -> Bool {
+    public func contains(trait: UIFontDescriptor.SymbolicTraits) -> Bool {
         return traits.contains(trait)
     }
 
-    func toggled(trait: UIFontDescriptor.SymbolicTraits) -> UIFont {
+    public func toggled(trait: UIFontDescriptor.SymbolicTraits) -> UIFont {
         let updatedFont: UIFont
         if self.contains(trait: trait) {
             updatedFont = removing(trait: trait)
@@ -53,7 +53,7 @@ public extension UIFont {
         return updatedFont
     }
 
-    func adding(trait: UIFontDescriptor.SymbolicTraits) -> UIFont {
+    public func adding(trait: UIFontDescriptor.SymbolicTraits) -> UIFont {
         var traits = self.traits
         traits.formUnion(trait)
         guard let updatedFontDescriptor = fontDescriptor.withSymbolicTraits(traits) else {
@@ -63,7 +63,7 @@ public extension UIFont {
         return UIFont(descriptor: updatedFontDescriptor, size: 0.0)
     }
 
-    func removing(trait: UIFontDescriptor.SymbolicTraits) -> UIFont {
+    public func removing(trait: UIFontDescriptor.SymbolicTraits) -> UIFont {
         var traits = self.traits
         traits.subtract(trait)
         guard let updatedFontDescriptor = fontDescriptor.withSymbolicTraits(traits) else {

--- a/Proton/Sources/Helpers/UITextRangeExtensions.swift
+++ b/Proton/Sources/Helpers/UITextRangeExtensions.swift
@@ -9,8 +9,8 @@
 import Foundation
 import UIKit
 
-public extension UITextRange {
-    func toNSRange(in input: UITextInput) -> NSRange? {
+extension UITextRange {
+    public func toNSRange(in input: UITextInput) -> NSRange? {
         let location = input.offset(from: input.beginningOfDocument, to: start)
         let length = input.offset(from: start, to: end)
         return NSRange(location: location, length: length)

--- a/Proton/Sources/Renderer/RendererView.swift
+++ b/Proton/Sources/Renderer/RendererView.swift
@@ -25,7 +25,8 @@ open class RendererView: UIView {
     ///   `RendererCommandExecutor` needs to have same context as the `RendererView` to execute a command on it. Unless you need to have
     ///    restriction around some commands to be restricted in execution on certain specific renderers, the default value may be used.
     public init(frame: CGRect = .zero, context: RendererViewContext = .shared) {
-        readOnlyEditorView = EditorView(frame: frame, richTextViewContext: context.richTextRendererContext)
+        readOnlyEditorView = EditorView(
+            frame: frame, richTextViewContext: context.richTextRendererContext)
         super.init(frame: frame)
         setup()
     }
@@ -152,23 +153,31 @@ open class RendererView: UIView {
 }
 
 extension RendererView: RichTextViewDelegate {
-    func richTextView(_ richTextView: RichTextView, didChangeSelection range: NSRange, attributes: [NSAttributedString.Key: Any], contentType: EditorContent.Name) {
+    func richTextView(
+        _ richTextView: RichTextView, didChangeSelection range: NSRange,
+        attributes: [NSAttributedString.Key: Any], contentType: EditorContent.Name
+    ) {
         delegate?.didChangeSelection(self, range: range)
     }
 
-    func richTextView(_ richTextView: RichTextView, didReceiveKey key: EditorKey, at range: NSRange, handled: inout Bool) { }
+    func richTextView(
+        _ richTextView: RichTextView, didReceiveKey key: EditorKey, at range: NSRange,
+        handled: inout Bool
+    ) {}
 
-    func richTextView(_ richTextView: RichTextView, didReceiveFocusAt range: NSRange) { }
+    func richTextView(_ richTextView: RichTextView, didReceiveFocusAt range: NSRange) {}
 
-    func richTextView(_ richTextView: RichTextView, didLoseFocusFrom range: NSRange) { }
+    func richTextView(_ richTextView: RichTextView, didLoseFocusFrom range: NSRange) {}
 
-    func richTextView(_ richTextView: RichTextView, didChangeTextAtRange range: NSRange) { }
+    func richTextView(_ richTextView: RichTextView, didChangeTextAtRange range: NSRange) {}
 
     func richTextView(_ richTextView: RichTextView, didFinishLayout finished: Bool) {
         readOnlyEditorView.relayoutAttachments()
     }
 
-    func richTextView(_ richTextView: RichTextView, didTapAtLocation location: CGPoint, characterRange: NSRange?) {
+    func richTextView(
+        _ richTextView: RichTextView, didTapAtLocation location: CGPoint, characterRange: NSRange?
+    ) {
         delegate?.didTap(self, didTapAtLocation: location, characterRange: characterRange)
     }
 }

--- a/Proton/Sources/Renderer/RendererViewDelegate.swift
+++ b/Proton/Sources/Renderer/RendererViewDelegate.swift
@@ -6,10 +6,13 @@
 //  Copyright © 2020 Rajdeep Kwatra. All rights reserved.
 //
 
-import Foundation
 import CoreGraphics
+import Foundation
 
 public protocol RendererViewDelegate: AnyObject {
-    func didTap(_ renderer: RendererView, didTapAtLocation location: CGPoint, characterRange: NSRange?)
+    func didTap(
+        _ renderer: RendererView, didTapAtLocation location: CGPoint, characterRange: NSRange?
+    )
+
     func didChangeSelection(_ renderer: RendererView, range: NSRange)
 }

--- a/Proton/Sources/RendererCommand/HighlightTextCommand.swift
+++ b/Proton/Sources/RendererCommand/HighlightTextCommand.swift
@@ -9,8 +9,8 @@
 import Foundation
 import UIKit
 
-public extension NSAttributedString.Key {
-    static let isHighlighted = NSAttributedString.Key("IsHighlighted")
+extension NSAttributedString.Key {
+    public static let isHighlighted = NSAttributedString.Key("IsHighlighted")
 }
 
 public class HighlightTextCommand: RendererCommand {
@@ -22,19 +22,24 @@ public class HighlightTextCommand: RendererCommand {
             return UIColor(red: 1.0, green: 0.98, blue: 0.80, alpha: 1.0)
         }
     })
-    public init() { }
+
+    public init() {}
+
     public func execute(on renderer: RendererView) {
         guard renderer.selectedText.length > 0 else { return }
-        let highlightedColor = renderer.selectedText.attribute(.backgroundColor, at: 0, effectiveRange: nil) as? UIColor
+        let highlightedColor = renderer.selectedText.attribute(
+            .backgroundColor, at: 0, effectiveRange: nil) as? UIColor
 
         guard highlightedColor != color else {
-            renderer.removeAttributes([.backgroundColor, .isHighlighted], at: renderer.selectedRange)
+            renderer.removeAttributes(
+                [.backgroundColor, .isHighlighted], at: renderer.selectedRange)
             return
         }
 
-        renderer.addAttributes([
-            .backgroundColor: color,
-            .isHighlighted: true,
-        ], at: renderer.selectedRange)
+        renderer.addAttributes(
+            [
+                .backgroundColor: color,
+                .isHighlighted: true,
+            ], at: renderer.selectedRange)
     }
 }

--- a/Proton/Sources/RendererCommand/RendererCommand.swift
+++ b/Proton/Sources/RendererCommand/RendererCommand.swift
@@ -24,8 +24,8 @@ public protocol RendererCommand {
     func execute(on renderer: RendererView)
 }
 
-public extension RendererCommand {
-    func canExecute(on renderer: RendererView) -> Bool {
+extension RendererCommand {
+    public func canExecute(on renderer: RendererView) -> Bool {
         return true
     }
 }

--- a/Proton/Sources/RendererCommand/RendererCommandExecutor.swift
+++ b/Proton/Sources/RendererCommand/RendererCommandExecutor.swift
@@ -28,7 +28,8 @@ public class RendererCommandExecutor {
         guard let activeRenderer = context.activeTextView,
             let editor = activeRenderer.superview as? EditorView,
             let renderer = editor.superview as? RendererView,
-            command.canExecute(on: renderer) else { return }
+            command.canExecute(on: renderer)
+        else { return }
         command.execute(on: renderer)
     }
 }

--- a/Proton/Sources/TextProcessors/TextProcessing.swift
+++ b/Proton/Sources/TextProcessors/TextProcessing.swift
@@ -10,11 +10,11 @@ import Foundation
 import UIKit
 
 public typealias TextProcessingPriority = Int
-public extension TextProcessingPriority {
-    static let exclusive: TextProcessingPriority = 1000
-    static let high: TextProcessingPriority = 750
-    static let medium: TextProcessingPriority = 500
-    static let low: TextProcessingPriority = 250
+extension TextProcessingPriority {
+    public static let exclusive: TextProcessingPriority = 1000
+    public static let high: TextProcessingPriority = 750
+    public static let medium: TextProcessingPriority = 500
+    public static let low: TextProcessingPriority = 250
 }
 
 public typealias Processed = Bool
@@ -42,15 +42,16 @@ public protocol TextProcessing {
     /// - Parameter processed: Set this to `true` is the `TextProcessor` has made any changes to the text or attributes in the `EditorView`
     /// - Returns: Return `true` to indicate the processing had been done by the current processor. In case of .exclusive priority processors,
     /// returning `true` notifies all other processors of interruption.
-    func process(editor: EditorView, range editedRange: NSRange, changeInLength delta: Int) -> Processed
+    func process(editor: EditorView, range editedRange: NSRange, changeInLength delta: Int)
+        -> Processed
 
     /// Fired when processing has been interrupted by another `TextProcessor` running in the same pass. This allows `TextProcessor` to revert
     /// any changes that may not have been committed.
     /// - Parameter editor:`EditorView` in which text is being changed.
     /// - Parameter range: Current range that is being modified.
-    func processInterrupted(editor: EditorView, at range: NSRange) // fired when processor is interrupted as a result of an exclusive priority processor
+    func processInterrupted(editor: EditorView, at range: NSRange)  // fired when processor is interrupted as a result of an exclusive priority processor
 }
 
-public extension TextProcessing {
-    func willProcess(deletedText: NSAttributedString, insertedText: String) { }
+extension TextProcessing {
+    public func willProcess(deletedText: NSAttributedString, insertedText: String) {}
 }

--- a/Proton/Sources/TextProcessors/TextProcessor.swift
+++ b/Proton/Sources/TextProcessors/TextProcessor.swift
@@ -39,7 +39,10 @@ class TextProcessor: NSObject, NSTextStorageDelegate {
         }
     }
 
-    func textStorage(_ textStorage: NSTextStorage, willProcessEditing editedMask: NSTextStorage.EditActions, range editedRange: NSRange, changeInLength delta: Int) {
+    func textStorage(
+        _ textStorage: NSTextStorage, willProcessEditing editedMask: NSTextStorage.EditActions,
+        range editedRange: NSRange, changeInLength delta: Int
+    ) {
         guard let editor = editor else { return }
 
         var processed = false
@@ -52,13 +55,18 @@ class TextProcessor: NSObject, NSTextStorageDelegate {
         }
     }
 
-    func textStorage(_ textStorage: NSTextStorage, willProcessDeletedText deletedText: NSAttributedString, insertedText: String) {
+    func textStorage(
+        _ textStorage: NSTextStorage, willProcessDeletedText deletedText: NSAttributedString,
+        insertedText: String
+    ) {
         for processor in sortedProcessors {
             processor.willProcess(deletedText: deletedText, insertedText: insertedText)
         }
     }
 
-    private func notifyInterruption(by processor: TextProcessing, editor: EditorView, at range: NSRange) {
+    private func notifyInterruption(
+        by processor: TextProcessing, editor: EditorView, at range: NSRange
+    ) {
         let processors = activeProcessors.filter { $0.name != processor.name }
         processors.forEach { $0.processInterrupted(editor: editor, at: range) }
     }

--- a/Proton/Tests/Attachments/AttachmentSnapshotTests.swift
+++ b/Proton/Tests/Attachments/AttachmentSnapshotTests.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2020 Rajdeep Kwatra. All rights reserved.
 //
 
+import FBSnapshotTestCase
 import Foundation
 import XCTest
-import FBSnapshotTestCase
 
 @testable import Proton
 
@@ -41,7 +41,8 @@ class AttachmentSnapshotTests: FBSnapshotTestCase {
 
         textView.replaceCharacters(in: .zero, with: "In textView")
         textView.insertAttachment(in: textView.textEndRange, attachment: attachment)
-        textView.replaceCharacters(in: textView.textEndRange, with: NSAttributedString(string: "after."))
+        textView.replaceCharacters(
+            in: textView.textEndRange, with: NSAttributedString(string: "after."))
 
         viewController.render()
         FBSnapshotVerifyView(viewController.view)
@@ -64,7 +65,8 @@ class AttachmentSnapshotTests: FBSnapshotTestCase {
         let viewController = EditorTestViewController()
         let textView = viewController.editor
 
-        let attachment = makeDummyAttachment(text: "fixed width attachment", size: .fixed(width: 100))
+        let attachment = makeDummyAttachment(
+            text: "fixed width attachment", size: .fixed(width: 100))
 
         textView.replaceCharacters(in: .zero, with: "In textView ")
         textView.insertAttachment(in: textView.textEndRange, attachment: attachment)
@@ -79,8 +81,9 @@ class AttachmentSnapshotTests: FBSnapshotTestCase {
         let textView = viewController.editor
 
         // TODO: validate incorrect snapshot rendering
-//        let attachment = makeDummyAttachment(text: "percent width attachment", size: .percent(width: 75))
-        let attachment = makeDummyAttachment(text: "attachment with percent based width", size: .percent(width: 75))
+        //        let attachment = makeDummyAttachment(text: "percent width attachment", size: .percent(width: 75))
+        let attachment = makeDummyAttachment(
+            text: "attachment with percent based width", size: .percent(width: 75))
 
         textView.replaceCharacters(in: .zero, with: "In textView")
         textView.insertAttachment(in: textView.textEndRange, attachment: attachment)
@@ -93,8 +96,10 @@ class AttachmentSnapshotTests: FBSnapshotTestCase {
         let viewController = EditorTestViewController()
         let textView = viewController.editor
 
-        let attachment1 = makeDummyAttachment(text: "short", size: .range(minWidth: 60, maxWidth: 200))
-        let attachment2 = makeDummyAttachment(text: "some relatively long text", size: .range(minWidth: 60, maxWidth: 200))
+        let attachment1 = makeDummyAttachment(
+            text: "short", size: .range(minWidth: 60, maxWidth: 200))
+        let attachment2 = makeDummyAttachment(
+            text: "some relatively long text", size: .range(minWidth: 60, maxWidth: 200))
 
         textView.replaceCharacters(in: .zero, with: "Short text ")
         textView.insertAttachment(in: textView.textEndRange, attachment: attachment1)
@@ -118,7 +123,11 @@ class AttachmentSnapshotTests: FBSnapshotTestCase {
 }
 
 extension AttachmentSnapshotTests: AttachmentOffsetProviding {
-    func offset(for attachment: Attachment, in textContainer: NSTextContainer, proposedLineFragment lineFrag: CGRect, glyphPosition position: CGPoint, characterIndex charIndex: Int) -> CGPoint {
+    func offset(
+        for attachment: Attachment, in textContainer: NSTextContainer,
+        proposedLineFragment lineFrag: CGRect, glyphPosition position: CGPoint,
+        characterIndex charIndex: Int
+    ) -> CGPoint {
         return CGPoint(x: 0, y: -3)
     }
 }

--- a/Proton/Tests/Base/AutogrowingTextViewSnapshotTests.swift
+++ b/Proton/Tests/Base/AutogrowingTextViewSnapshotTests.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2020 Rajdeep Kwatra. All rights reserved.
 //
 
+import FBSnapshotTestCase
 import Foundation
 import XCTest
-import FBSnapshotTestCase
 
 @testable import Proton
 
@@ -31,7 +31,7 @@ class AutogrowingTextViewSnapshotTests: FBSnapshotTestCase {
         view.addSubview(textView)
         NSLayoutConstraint.activate([
             textView.topAnchor.constraint(equalTo: view.topAnchor, constant: 20),
-            textView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20)
+            textView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
         ])
 
         viewController.render()
@@ -43,7 +43,8 @@ class AutogrowingTextViewSnapshotTests: FBSnapshotTestCase {
         let viewController = SnapshotTestViewController()
         let textView = AutogrowingTextView()
         textView.translatesAutoresizingMaskIntoConstraints = false
-        textView.text = "Sample with multiple lines of text. This text flows into the second line because of width constraint on textview"
+        textView.text =
+            "Sample with multiple lines of text. This text flows into the second line because of width constraint on textview"
         textView.addBorder()
 
         let view = viewController.view!
@@ -51,7 +52,7 @@ class AutogrowingTextViewSnapshotTests: FBSnapshotTestCase {
         NSLayoutConstraint.activate([
             textView.widthAnchor.constraint(equalToConstant: 280),
             textView.topAnchor.constraint(equalTo: view.topAnchor, constant: 20),
-            textView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 10)
+            textView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 10),
         ])
 
         viewController.render()

--- a/Proton/Tests/Base/AutogrowingTextViewTests.swift
+++ b/Proton/Tests/Base/AutogrowingTextViewTests.swift
@@ -33,11 +33,12 @@ class AutogrowingTextViewTests: XCTestCase {
         NSLayoutConstraint.activate([
             textView.widthAnchor.constraint(equalToConstant: 80),
             textView.topAnchor.constraint(equalTo: view.topAnchor, constant: 20),
-            textView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20)
+            textView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
         ])
 
         viewController.render()
-        textView.text = "Sample with single line text Sample with single line text Sample with single line text"
+        textView.text =
+            "Sample with single line text Sample with single line text Sample with single line text"
 
         viewController.render()
 

--- a/Proton/Tests/Core/Mocks/MockRichTextViewDelegate.swift
+++ b/Proton/Tests/Core/Mocks/MockRichTextViewDelegate.swift
@@ -12,7 +12,9 @@ import UIKit
 @testable import Proton
 
 class MockRichTextViewDelegate: RichTextViewDelegate {
-    var onSelectionChanged: ((RichTextView, NSRange, [NSAttributedString.Key: Any], EditorContent.Name) -> Void)?
+    var onSelectionChanged:
+        ((RichTextView, NSRange, [NSAttributedString.Key: Any], EditorContent.Name) -> Void)?
+
     var onKeyReceived: ((RichTextView, EditorKey, NSRange, Bool) -> Void)?
     var onReceivedFocus: ((RichTextView, NSRange) -> Void)?
     var onLostFocus: ((RichTextView, NSRange) -> Void)?
@@ -20,11 +22,17 @@ class MockRichTextViewDelegate: RichTextViewDelegate {
     var onDidFinishLayout: ((RichTextView, Bool) -> Void)?
     var onDidTapAtLocation: ((RichTextView, CGPoint, NSRange?) -> Void)?
 
-    func richTextView(_ richTextView: RichTextView, didChangeSelection range: NSRange, attributes: [NSAttributedString.Key: Any], contentType: EditorContent.Name) {
+    func richTextView(
+        _ richTextView: RichTextView, didChangeSelection range: NSRange,
+        attributes: [NSAttributedString.Key: Any], contentType: EditorContent.Name
+    ) {
         onSelectionChanged?(richTextView, range, attributes, contentType)
     }
 
-    func richTextView(_ richTextView: RichTextView, didReceiveKey key: EditorKey, at range: NSRange, handled: inout Bool) {
+    func richTextView(
+        _ richTextView: RichTextView, didReceiveKey key: EditorKey, at range: NSRange,
+        handled: inout Bool
+    ) {
         onKeyReceived?(richTextView, key, range, handled)
     }
 
@@ -44,7 +52,9 @@ class MockRichTextViewDelegate: RichTextViewDelegate {
         onDidChangeText?(richTextView, range)
     }
 
-    func richTextView(_ richTextView: RichTextView, didTapAtLocation location: CGPoint, characterRange: NSRange?) {
+    func richTextView(
+        _ richTextView: RichTextView, didTapAtLocation location: CGPoint, characterRange: NSRange?
+    ) {
         onDidTapAtLocation?(richTextView, location, characterRange)
     }
 }

--- a/Proton/Tests/Core/RichTextViewSnapshotTests.swift
+++ b/Proton/Tests/Core/RichTextViewSnapshotTests.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2020 Rajdeep Kwatra. All rights reserved.
 //
 
+import FBSnapshotTestCase
 import Foundation
 import XCTest
-import FBSnapshotTestCase
 
 @testable import Proton
 
@@ -31,7 +31,7 @@ class RichTextViewSnapshotTests: FBSnapshotTestCase {
         view.addSubview(textView)
         NSLayoutConstraint.activate([
             textView.topAnchor.constraint(equalTo: view.topAnchor, constant: 20),
-            textView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20)
+            textView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
         ])
 
         viewController.render()
@@ -48,11 +48,13 @@ class RichTextViewSnapshotTests: FBSnapshotTestCase {
         paragraphStyle.firstLineHeadIndent = 10
         paragraphStyle.lineSpacing = 6
 
-        let formattingProvider = MockDefaultTextFormattingProvider(font: font, paragraphStyle: paragraphStyle)
+        let formattingProvider = MockDefaultTextFormattingProvider(
+            font: font, paragraphStyle: paragraphStyle)
         textView.defaultTextFormattingProvider = formattingProvider
 
         textView.translatesAutoresizingMaskIntoConstraints = false
-        textView.text = "Sample with multiple lines of text. This text flows into the second line because of width constraint on textview"
+        textView.text =
+            "Sample with multiple lines of text. This text flows into the second line because of width constraint on textview"
         textView.addBorder()
 
         let view = viewController.view!
@@ -60,7 +62,7 @@ class RichTextViewSnapshotTests: FBSnapshotTestCase {
         NSLayoutConstraint.activate([
             textView.widthAnchor.constraint(equalToConstant: 280),
             textView.topAnchor.constraint(equalTo: view.topAnchor, constant: 20),
-            textView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 10)
+            textView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 10),
         ])
 
         viewController.render(size: CGSize(width: 300, height: 150))

--- a/Proton/Tests/Core/RichTextViewTests.swift
+++ b/Proton/Tests/Core/RichTextViewTests.swift
@@ -27,7 +27,7 @@ class RichTextViewTests: XCTestCase {
         view.addSubview(textView)
         NSLayoutConstraint.activate([
             textView.topAnchor.constraint(equalTo: view.topAnchor, constant: 20),
-            textView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20)
+            textView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
         ])
 
         viewController.render()
@@ -52,7 +52,8 @@ class RichTextViewTests: XCTestCase {
         XCTAssertEqual(preColor, UIColor.blue)
         textView.deleteBackward()
         let postColor = try XCTUnwrap(textView.typingAttributes[.foregroundColor] as? UIColor)
-        let typingAttributeColor = try XCTUnwrap(textView.defaultTypingAttributes[.foregroundColor] as? UIColor)
+        let typingAttributeColor = try XCTUnwrap(
+            textView.defaultTypingAttributes[.foregroundColor] as? UIColor)
         XCTAssertEqual(postColor, typingAttributeColor)
 
     }

--- a/Proton/Tests/Core/TextStorageTests.swift
+++ b/Proton/Tests/Core/TextStorageTests.swift
@@ -33,7 +33,8 @@ class TextStorageTests: XCTestCase {
         paragraphStyle.lineSpacing = 10
         paragraphStyle.firstLineHeadIndent = 6
 
-        let textFormattingProvider = MockDefaultTextFormattingProvider(font: font, paragraphStyle: paragraphStyle)
+        let textFormattingProvider = MockDefaultTextFormattingProvider(
+            font: font, paragraphStyle: paragraphStyle)
 
         let string = "This is a test string"
         textStorage.defaultTextFormattingProvider = textFormattingProvider
@@ -80,10 +81,13 @@ class TextStorageTests: XCTestCase {
         XCTAssertNil(attributes[key])
         XCTAssertEqual(effectiveRange, range)
 
-        let keyAttributes = textStorage.attributes(at: range.length, effectiveRange: &effectiveRange)
+        let keyAttributes = textStorage.attributes(
+            at: range.length, effectiveRange: &effectiveRange)
 
         XCTAssertEqual(keyAttributes[key] as? Bool, true)
-        XCTAssertEqual(effectiveRange, NSRange(location: range.length, length: testString.count - range.length))
+        XCTAssertEqual(
+            effectiveRange, NSRange(location: range.length, length: testString.count - range.length)
+        )
     }
 
     func testFixesMissingDefaultAttributesWhenRemoved() {
@@ -96,7 +100,8 @@ class TextStorageTests: XCTestCase {
         XCTAssertTrue(defaultAttributes.contains { $0.key == .foregroundColor })
         XCTAssertTrue(defaultAttributes.contains { $0.key == .paragraphStyle })
 
-        textStorage.removeAttributes([.font, .foregroundColor, .paragraphStyle], range: textStorage.fullRange)
+        textStorage.removeAttributes(
+            [.font, .foregroundColor, .paragraphStyle], range: textStorage.fullRange)
 
         let fixedAttributes = textStorage.attributes(at: 0, effectiveRange: nil)
         XCTAssertTrue(fixedAttributes.contains { $0.key == .font })

--- a/Proton/Tests/Editor/EditorContentTransformerTests.swift
+++ b/Proton/Tests/Editor/EditorContentTransformerTests.swift
@@ -7,10 +7,9 @@
 //
 
 import Foundation
+import Proton
 import UIKit
 import XCTest
-
-import Proton
 
 class EditorContentTransformerTests: XCTestCase {
     func testTransformsText() {

--- a/Proton/Tests/Editor/EditorSnapshotTests.swift
+++ b/Proton/Tests/Editor/EditorSnapshotTests.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2020 Rajdeep Kwatra. All rights reserved.
 //
 
+import FBSnapshotTestCase
 import Foundation
 import XCTest
-import FBSnapshotTestCase
 
 @testable import Proton
 
@@ -23,12 +23,15 @@ class EditorSnapshotTests: FBSnapshotTestCase {
         let viewController = EditorTestViewController(height: 80)
         let editor = viewController.editor
         let font = UIFont(name: "Verdana", size: 17) ?? UIFont()
-        let placeholderString = NSMutableAttributedString(string: "Placeholder text that is so long that it wraps into the next line", attributes: [
-            NSAttributedString.Key.font: font,
-            NSAttributedString.Key.foregroundColor: UIColor.lightGray
-        ])
+        let placeholderString = NSMutableAttributedString(
+            string: "Placeholder text that is so long that it wraps into the next line",
+            attributes: [
+                NSAttributedString.Key.font: font,
+                NSAttributedString.Key.foregroundColor: UIColor.lightGray,
+            ])
 
-        placeholderString.addAttribute(.font, value: font.adding(trait: .traitBold), range: NSRange(location: 12, length: 4))
+        placeholderString.addAttribute(
+            .font, value: font.adding(trait: .traitBold), range: NSRange(location: 12, length: 4))
 
         editor.placeholderText = placeholderString
         viewController.render(size: CGSize(width: 300, height: 120))
@@ -133,7 +136,8 @@ class EditorSnapshotTests: FBSnapshotTestCase {
 
         editor.replaceCharacters(in: .zero, with: "This text is in Editor ")
         editor.insertAttachment(in: editor.textEndRange, attachment: attachment)
-        editor.replaceCharacters(in: editor.textEndRange, with: "and then some more text after the attachment")
+        editor.replaceCharacters(
+            in: editor.textEndRange, with: "and then some more text after the attachment")
 
         viewController.render()
         FBSnapshotVerifyView(viewController.view)
@@ -182,7 +186,10 @@ class EditorSnapshotTests: FBSnapshotTestCase {
         editor.replaceCharacters(in: .zero, with: "This text is in Editor")
         editor.insertAttachment(in: editor.textEndRange, attachment: attachment)
 
-        editor.attributedText.enumerateAttribute(.attachment, in: editor.attributedText.fullRange, options: .longestEffectiveRangeNotRequired) { value, range, _ in
+        editor.attributedText.enumerateAttribute(
+            .attachment, in: editor.attributedText.fullRange,
+            options: .longestEffectiveRangeNotRequired
+        ) { value, range, _ in
             if value != nil {
                 editor.replaceCharacters(in: range, with: "")
             }
@@ -195,7 +202,8 @@ class EditorSnapshotTests: FBSnapshotTestCase {
     func testGetsRectsForGivenRangeSpanningAcrossMultipleLines() {
         let viewController = EditorTestViewController()
         let editor = viewController.editor
-        editor.attributedText = NSAttributedString(string: "This is some long string that wraps into the next line.")
+        editor.attributedText = NSAttributedString(
+            string: "This is some long string that wraps into the next line.")
         viewController.render()
         let rects = editor.rects(for: NSRange(location: 25, length: 10))
         for rect in rects {
@@ -211,7 +219,8 @@ class EditorSnapshotTests: FBSnapshotTestCase {
     func testGetsRectsForGivenRangeSpanningAcrossSingleLine() {
         let viewController = EditorTestViewController()
         let editor = viewController.editor
-        editor.attributedText = NSAttributedString(string: "This is some long string that wraps into the next line.")
+        editor.attributedText = NSAttributedString(
+            string: "This is some long string that wraps into the next line.")
         viewController.render()
         let rects = editor.rects(for: NSRange(location: 10, length: 10))
         for rect in rects {
@@ -227,7 +236,8 @@ class EditorSnapshotTests: FBSnapshotTestCase {
     func testGetsCaretRectForValidPosition() {
         let viewController = EditorTestViewController()
         let editor = viewController.editor
-        editor.attributedText = NSAttributedString(string: "This is some long string that wraps into the next line.")
+        editor.attributedText = NSAttributedString(
+            string: "This is some long string that wraps into the next line.")
         viewController.render()
         let rect = editor.caretRect(for: 10)
         let view = UIView(frame: rect)
@@ -283,7 +293,8 @@ class EditorSnapshotTests: FBSnapshotTestCase {
 
         let visibleRange = editor.visibleRange
         // refer to snapshot for visible text
-        let expectedText = "consectetur, from a Lorem Ipsum passage, and going through the cites of the word in "
+        let expectedText =
+            "consectetur, from a Lorem Ipsum passage, and going through the cites of the word in "
         let visibleText = editor.attributedText.attributedSubstring(from: visibleRange).string
         XCTAssertEqual(visibleText, expectedText)
     }
@@ -293,9 +304,9 @@ class EditorSnapshotTests: FBSnapshotTestCase {
         let editor = viewController.editor
 
         let text =
-        """
-        Line 1 text Line 1 text Line 1 text Line 2 text Line 2 text
-        """
+            """
+            Line 1 text Line 1 text Line 1 text Line 2 text Line 2 text
+            """
 
         let line1Location = NSRange(location: 10, length: 1)
         let line2Location = NSRange(location: 40, length: 1)
@@ -327,9 +338,9 @@ class EditorSnapshotTests: FBSnapshotTestCase {
         let editor = viewController.editor
 
         let text =
-        """
-        Line 1 text Line 1 text Line 1 text Line 2 text Line 2 text Line 2 text Line 3 text Line 3
-        """
+            """
+            Line 1 text Line 1 text Line 1 text Line 2 text Line 2 text Line 2 text Line 3 text Line 3
+            """
 
         let line1Location = NSRange(location: 10, length: 1)
         let line2Location = NSRange(location: 40, length: 1)
@@ -366,22 +377,28 @@ class EditorSnapshotTests: FBSnapshotTestCase {
         let viewController = EditorTestViewController()
         let editor = viewController.editor
 
-        let styles: [(String, pointSize: CGFloat, UIFont.Weight, paragraphBefore: CGFloat, paragraphAfter: CGFloat)] = [
-            ("Heading 1", 27, .medium, 50, 15),
-            ("Heading 2", 23.5, .medium, 22, 15),
-            ("Heading 3", 17, .semibold, 20, 16),
-            ("Heading 4", 17, .semibold, 4, 15),
-            ("Heading 5", 14, .semibold, 5, 15),
-            ("Heading 6", 12, .semibold, 4, 15),
-        ]
-        let para = NSAttributedString(string: "para --\n", attributes: [
-            .font: UIFont.preferredFont(forTextStyle: .body),
-            .paragraphStyle: { () -> NSMutableParagraphStyle in
-                let s = NSMutableParagraphStyle()
-                s.paragraphSpacing = 20
-                return s
-            }(),
-        ])
+        let styles:
+            [(
+                String, pointSize: CGFloat, UIFont.Weight, paragraphBefore: CGFloat,
+                paragraphAfter: CGFloat
+            )] = [
+                ("Heading 1", 27, .medium, 50, 15),
+                ("Heading 2", 23.5, .medium, 22, 15),
+                ("Heading 3", 17, .semibold, 20, 16),
+                ("Heading 4", 17, .semibold, 4, 15),
+                ("Heading 5", 14, .semibold, 5, 15),
+                ("Heading 6", 12, .semibold, 4, 15),
+            ]
+        let para = NSAttributedString(
+            string: "para --\n",
+            attributes: [
+                .font: UIFont.preferredFont(forTextStyle: .body),
+                .paragraphStyle: { () -> NSMutableParagraphStyle in
+                    let s = NSMutableParagraphStyle()
+                    s.paragraphSpacing = 20
+                    return s
+                }(),
+            ])
         let text = NSMutableAttributedString()
         text.append(NSAttributedString(string: "para --\n"))
         for style in styles {
@@ -393,10 +410,13 @@ class EditorSnapshotTests: FBSnapshotTestCase {
                 NSTextTab(textAlignment: .natural, location: 30, options: [:]),
                 NSTextTab(textAlignment: .natural, location: 60, options: [:]),
             ]
-            text.append(NSAttributedString(string: "\(style.0)\n", attributes: [
-                .font: UIFont.systemFont(ofSize: style.pointSize, weight: style.2),
-                .paragraphStyle: pstyle,
-            ]))
+            text.append(
+                NSAttributedString(
+                    string: "\(style.0)\n",
+                    attributes: [
+                        .font: UIFont.systemFont(ofSize: style.pointSize, weight: style.2),
+                        .paragraphStyle: pstyle,
+                    ]))
             text.append(para)
         }
 

--- a/Proton/Tests/Editor/EditorViewDelegateTests.swift
+++ b/Proton/Tests/Editor/EditorViewDelegateTests.swift
@@ -29,7 +29,8 @@ class EditorViewDelegateTests: XCTestCase {
         let richTextViewDelegate = richTextView.richTextViewDelegate
         var handled = true
 
-        richTextViewDelegate?.richTextView(richTextView, didReceiveKey: .enter, at: .zero, handled: &handled)
+        richTextViewDelegate?.richTextView(
+            richTextView, didReceiveKey: .enter, at: .zero, handled: &handled)
         waitForExpectations(timeout: 1.0)
     }
 
@@ -49,7 +50,8 @@ class EditorViewDelegateTests: XCTestCase {
         let richTextView = editor.richTextView
         let richTextViewDelegate = richTextView.richTextViewDelegate
 
-        richTextViewDelegate?.richTextView(richTextView, didChangeSelection: .zero, attributes: [:], contentType: .paragraph)
+        richTextViewDelegate?.richTextView(
+            richTextView, didChangeSelection: .zero, attributes: [:], contentType: .paragraph)
         waitForExpectations(timeout: 1.0)
     }
 

--- a/Proton/Tests/Editor/EditorViewTests.swift
+++ b/Proton/Tests/Editor/EditorViewTests.swift
@@ -70,7 +70,8 @@ class EditorViewTests: XCTestCase {
         let spacerContent1 = contents[2]
         if case let .text(name, attributedString) = spacerContent1.type {
             XCTAssertEqual(name, EditorContent.Name.paragraph)
-            XCTAssertEqual(attributedString.string.trimmingCharacters(in: .whitespacesAndNewlines), "")
+            XCTAssertEqual(
+                attributedString.string.trimmingCharacters(in: .whitespacesAndNewlines), "")
         } else {
             XCTFail("Failed to get correct content [Spacer]")
         }
@@ -87,7 +88,8 @@ class EditorViewTests: XCTestCase {
         let spacerContent2 = contents[4]
         if case let .text(name, attributedString) = spacerContent2.type {
             XCTAssertEqual(name, EditorContent.Name.newline)
-            XCTAssertEqual(attributedString.string.trimmingCharacters(in: .whitespacesAndNewlines), "")
+            XCTAssertEqual(
+                attributedString.string.trimmingCharacters(in: .whitespacesAndNewlines), "")
         } else {
             XCTFail("Failed to get correct content [Spacer]")
         }
@@ -131,7 +133,9 @@ class EditorViewTests: XCTestCase {
         let transformedContents = editor.transformContents(using: TextTransformer())
         XCTAssertEqual(transformedContents.count, 3)
         XCTAssertEqual(transformedContents[0], "Name: `paragraph` Text: `Some text in Editor `")
-        XCTAssertEqual(transformedContents[1], "Name: `textField` ContentView: `AutogrowingTextField` Type: `inline`")
+        XCTAssertEqual(
+            transformedContents[1],
+            "Name: `textField` ContentView: `AutogrowingTextField` Type: `inline`")
         XCTAssertEqual(transformedContents[2], "Name: `paragraph` Text: ` `")
     }
 
@@ -166,7 +170,8 @@ class EditorViewTests: XCTestCase {
 
         editor.replaceCharacters(in: .zero, with: testString)
         editor.insertAttachment(in: editor.textEndRange, attachment: attachment)
-        editor.addAttributes(attributesToAdd, at: NSRange(location: 7, length: editor.contentLength - 7))
+        editor.addAttributes(
+            attributesToAdd, at: NSRange(location: 7, length: editor.contentLength - 7))
         waitForExpectations(timeout: 1.0)
     }
 
@@ -340,7 +345,7 @@ class EditorViewTests: XCTestCase {
         editor.registerCommand(command)
 
         XCTAssertEqual(editor.registeredCommands?.count, 1)
-        XCTAssertTrue(editor.registeredCommands?.contains{ $0 === command } ?? false)
+        XCTAssertTrue(editor.registeredCommands?.contains { $0 === command } ?? false)
     }
 
     func testUnregistersCommands() {
@@ -352,7 +357,7 @@ class EditorViewTests: XCTestCase {
 
         editor.unregisterCommand(command1)
         XCTAssertEqual(editor.registeredCommands?.count, 1)
-        XCTAssertTrue(editor.registeredCommands?.contains{ $0 === command2 } ?? false)
+        XCTAssertTrue(editor.registeredCommands?.contains { $0 === command2 } ?? false)
     }
 
     func testReturnsNilForInvalidNextLine() throws {
@@ -378,11 +383,13 @@ class EditorViewTests: XCTestCase {
     func testResetsAttributesWhenCleared() {
         let editor = EditorView()
         editor.textColor = UIColor.red
-        let attrString = NSMutableAttributedString(string: "This is a test string", attributes: [.foregroundColor: UIColor.blue])
+        let attrString = NSMutableAttributedString(
+            string: "This is a test string", attributes: [.foregroundColor: UIColor.blue])
         editor.attributedText = attrString
         editor.clear()
         editor.appendCharacters(NSAttributedString(string: "test"))
-        let color = editor.attributedText.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? UIColor
+        let color = editor.attributedText.attribute(.foregroundColor, at: 0, effectiveRange: nil)
+            as? UIColor
         XCTAssertEqual(color, editor.textColor)
     }
 }

--- a/Proton/Tests/Editor/Mocks/MockAttachment.swift
+++ b/Proton/Tests/Editor/Mocks/MockAttachment.swift
@@ -7,19 +7,22 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 class MockAttachment: Attachment {
     var onAddedAttributesOnContainingRange: ((NSRange, [NSAttributedString.Key: Any]) -> Void)?
     var onRemovedAttributesFromContainingRange: ((NSRange, [NSAttributedString.Key]) -> Void)?
 
-    override func addedAttributesOnContainingRange(rangeInContainer range: NSRange, attributes: [NSAttributedString.Key: Any]) {
+    override func addedAttributesOnContainingRange(
+        rangeInContainer range: NSRange, attributes: [NSAttributedString.Key: Any]
+    ) {
         onAddedAttributesOnContainingRange?(range, attributes)
     }
 
-    override func removedAttributesFromContainingRange(rangeInContainer range: NSRange, attributes: [NSAttributedString.Key]) {
+    override func removedAttributesFromContainingRange(
+        rangeInContainer range: NSRange, attributes: [NSAttributedString.Key]
+    ) {
         onRemovedAttributesFromContainingRange?(range, attributes)
     }
 }

--- a/Proton/Tests/Editor/Mocks/MockAttachmentOffsetProvider.swift
+++ b/Proton/Tests/Editor/Mocks/MockAttachmentOffsetProvider.swift
@@ -7,14 +7,17 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 class MockAttachmentOffsetProvider: AttachmentOffsetProviding {
     var offset = CGPoint.zero
 
-    func offset(for attachment: Attachment, in textContainer: NSTextContainer, proposedLineFragment lineFrag: CGRect, glyphPosition position: CGPoint, characterIndex charIndex: Int) -> CGPoint {
+    func offset(
+        for attachment: Attachment, in textContainer: NSTextContainer,
+        proposedLineFragment lineFrag: CGRect, glyphPosition position: CGPoint,
+        characterIndex charIndex: Int
+    ) -> CGPoint {
         return offset
     }
 }

--- a/Proton/Tests/Editor/Mocks/MockEditorViewDelegate.swift
+++ b/Proton/Tests/Editor/Mocks/MockEditorViewDelegate.swift
@@ -12,16 +12,23 @@ import UIKit
 @testable import Proton
 
 class MockEditorViewDelegate: EditorViewDelegate {
-    var onSelectionChanged: ((EditorView, NSRange, [NSAttributedString.Key: Any], EditorContent.Name) -> Void)?
+    var onSelectionChanged:
+        ((EditorView, NSRange, [NSAttributedString.Key: Any], EditorContent.Name) -> Void)?
+
     var onKeyReceived: ((EditorView, EditorKey, NSRange, Bool) -> Void)?
     var onReceivedFocus: ((EditorView, NSRange) -> Void)?
     var onLostFocus: ((EditorView, NSRange) -> Void)?
 
-    func editor(_ editor: EditorView, didChangeSelectionAt range: NSRange, attributes: [NSAttributedString.Key: Any], contentType: EditorContent.Name) {
+    func editor(
+        _ editor: EditorView, didChangeSelectionAt range: NSRange,
+        attributes: [NSAttributedString.Key: Any], contentType: EditorContent.Name
+    ) {
         onSelectionChanged?(editor, range, attributes, contentType)
     }
 
-    func editor(_ editor: EditorView, didReceiveKey key: EditorKey, at range: NSRange, handled: inout Bool) {
+    func editor(
+        _ editor: EditorView, didReceiveKey key: EditorKey, at range: NSRange, handled: inout Bool
+    ) {
         onKeyReceived?(editor, key, range, handled)
     }
 

--- a/Proton/Tests/EditorCommands/EditorCommandExecutorTests.swift
+++ b/Proton/Tests/EditorCommands/EditorCommandExecutorTests.swift
@@ -7,9 +7,8 @@
 //
 
 import Foundation
-import XCTest
-
 import Proton
+import XCTest
 
 class EditorCommandExecutorTests: XCTestCase {
     func testExecutesCommandOnEditor() {
@@ -21,7 +20,8 @@ class EditorCommandExecutorTests: XCTestCase {
         editor.replaceCharacters(in: .zero, with: "This is some text")
         editor.selectedRange = selectedRange
 
-        guard let font = editor.selectedText.attribute(.font, at: 0, effectiveRange: nil) as? UIFont else {
+        guard let font = editor.selectedText.attribute(.font, at: 0, effectiveRange: nil) as? UIFont
+        else {
             XCTFail("Failed to get font information")
             return
         }
@@ -30,7 +30,10 @@ class EditorCommandExecutorTests: XCTestCase {
 
         commandExecutor.execute(BoldCommand())
 
-        guard let updatedFont = editor.selectedText.attribute(.font, at: 0, effectiveRange: nil) as? UIFont else {
+        guard
+            let updatedFont = editor.selectedText.attribute(.font, at: 0, effectiveRange: nil)
+                as? UIFont
+        else {
             XCTFail("Failed to get font information")
             return
         }

--- a/Proton/Tests/EditorCommands/EditorCommandSnapshotTests.swift
+++ b/Proton/Tests/EditorCommands/EditorCommandSnapshotTests.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2020 Rajdeep Kwatra. All rights reserved.
 //
 
+import FBSnapshotTestCase
 import Foundation
 import XCTest
-import FBSnapshotTestCase
 
 @testable import Proton
 

--- a/Proton/Tests/EditorCommands/FontTraitToggleCommandTests.swift
+++ b/Proton/Tests/EditorCommands/FontTraitToggleCommandTests.swift
@@ -7,9 +7,8 @@
 //
 
 import Foundation
-import XCTest
-
 import Proton
+import XCTest
 
 class FontTraitToggleCommandTests: XCTestCase {
     func testSetsTypingAttributesInEmptyEditor() {
@@ -62,7 +61,9 @@ class FontTraitToggleCommandTests: XCTestCase {
             (text: "some text", isBold: false, isItalics: false),
         ]
         var counter = 0
-        editorText.enumerateAttribute(.font, in: editorText.fullRange, options: .longestEffectiveRangeNotRequired) { (font, range, _) in
+        editorText.enumerateAttribute(
+            .font, in: editorText.fullRange, options: .longestEffectiveRangeNotRequired
+        ) { (font, range, _) in
             let text = editorText.attributedSubstring(from: range)
             let font = assertUnwrap(text.attribute(.font, at: 0, effectiveRange: nil) as? UIFont)
             let expectedValue = expectedValues[counter]

--- a/Proton/Tests/EditorCommands/Mocks/MockEditorCommand.swift
+++ b/Proton/Tests/EditorCommands/Mocks/MockEditorCommand.swift
@@ -7,16 +7,17 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 class MockEditorCommand: EditorCommand {
     var onCanExecute: (EditorView) -> Bool
     var onExecute: (EditorView) -> Void
 
-    init(onCanExecute: @escaping ((EditorView) -> Bool) = { _ in true },
-         onExecute: @escaping ((EditorView) -> Void)) {
+    init(
+        onCanExecute: @escaping ((EditorView) -> Bool) = { _ in true },
+        onExecute: @escaping ((EditorView) -> Void)
+    ) {
         self.onCanExecute = onCanExecute
         self.onExecute = onExecute
     }

--- a/Proton/Tests/Encoding/EditorContentEncoderTests.swift
+++ b/Proton/Tests/Encoding/EditorContentEncoderTests.swift
@@ -7,9 +7,8 @@
 //
 
 import Foundation
-import XCTest
-
 import Proton
+import XCTest
 
 //class EditorContentEncoderTests: XCTestCase {
 //    func testEncoding() {

--- a/Proton/Tests/ExtensionTests/NSAttributedStringExtensionTests.swift
+++ b/Proton/Tests/ExtensionTests/NSAttributedStringExtensionTests.swift
@@ -7,9 +7,8 @@
 //
 
 import Foundation
-import XCTest
-
 import Proton
+import XCTest
 
 class NSAttributedStringExtensionTests: XCTestCase {
     func testGetsFullRange() {

--- a/Proton/Tests/Helpers/EditorTestViewController.swift
+++ b/Proton/Tests/Helpers/EditorTestViewController.swift
@@ -7,9 +7,8 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 class EditorTestViewController: SnapshotTestViewController {
     let editor: EditorView
@@ -35,7 +34,7 @@ class EditorTestViewController: SnapshotTestViewController {
             editor.topAnchor.constraint(equalTo: view.topAnchor, constant: 20),
             editor.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
             view.trailingAnchor.constraint(equalTo: editor.trailingAnchor, constant: 20),
-            editor.bottomAnchor.constraint(lessThanOrEqualTo: view.bottomAnchor)
+            editor.bottomAnchor.constraint(lessThanOrEqualTo: view.bottomAnchor),
         ])
 
         guard let height = self.height else { return }

--- a/Proton/Tests/Helpers/RendererTestViewController.swift
+++ b/Proton/Tests/Helpers/RendererTestViewController.swift
@@ -7,9 +7,8 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 class RendererTestViewController: SnapshotTestViewController {
     let renderer: RendererView

--- a/Proton/Tests/Helpers/TextTransformer.swift
+++ b/Proton/Tests/Helpers/TextTransformer.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-
 import Proton
 
 class TextTransformer: EditorContentEncoding {
@@ -19,7 +18,8 @@ class TextTransformer: EditorContentEncoding {
         switch content.type {
         case let .attachment(name, contentView, attachmentType):
             let contentViewType = String(describing: type(of: contentView))
-            text = "Name: `\(name.rawValue)` ContentView: `\(contentViewType)` Type: `\(attachmentType)`"
+            text =
+                "Name: `\(name.rawValue)` ContentView: `\(contentViewType)` Type: `\(attachmentType)`"
         case let .text(name, attributedString):
             text = "Name: `\(name.rawValue)` Text: `\(attributedString.string)`"
         case .viewOnly:

--- a/Proton/Tests/Helpers/Views/AutogrowingTextField.swift
+++ b/Proton/Tests/Helpers/Views/AutogrowingTextField.swift
@@ -7,9 +7,8 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 class AutogrowingTextField: UITextField, UITextFieldDelegate {
     weak var boundsObserver: BoundsObserving?
@@ -22,7 +21,8 @@ class AutogrowingTextField: UITextField, UITextFieldDelegate {
     }
 
     override var intrinsicContentSize: CGSize {
-        let fittingSize = sizeThatFits(CGSize(width: .greatestFiniteMagnitude, height: frame.height))
+        let fittingSize = sizeThatFits(
+            CGSize(width: .greatestFiniteMagnitude, height: frame.height))
         // TODO: revisit to use invalidate intrinsic content size
         self.bounds = CGRect(origin: bounds.origin, size: fittingSize)
         return fittingSize

--- a/Proton/Tests/Helpers/Views/InlineEditorView.swift
+++ b/Proton/Tests/Helpers/Views/InlineEditorView.swift
@@ -7,9 +7,8 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 class InlineEditorView: EditorView, InlineContent {
     public var name: EditorContent.Name {

--- a/Proton/Tests/Helpers/Views/PanelView.swift
+++ b/Proton/Tests/Helpers/Views/PanelView.swift
@@ -7,9 +7,8 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 class PanelView: UIView, BlockContent, EditorContentView {
     let editor: EditorView
@@ -50,10 +49,11 @@ class PanelView: UIView, BlockContent, EditorContentView {
             iconView.topAnchor.constraint(equalTo: topAnchor, constant: 5),
             iconView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 5),
 
-            editor.topAnchor.constraint(equalTo: iconView.topAnchor, constant: -editor.textContainerInset.top),
+            editor.topAnchor.constraint(
+                equalTo: iconView.topAnchor, constant: -editor.textContainerInset.top),
             editor.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: 5),
             editor.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -5),
-            editor.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -5)
+            editor.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -5),
         ])
 
         iconView.layer.borderColor = UIColor.black.cgColor

--- a/Proton/Tests/Helpers/XCTestHelpers.swift
+++ b/Proton/Tests/Helpers/XCTestHelpers.swift
@@ -15,7 +15,10 @@ import XCTest
 ///   - value: Optional value
 ///   - message: Message to use in the test failure if the provided value is `nil`.
 /// - Returns: The unwrapped value
-public func assertUnwrap<T>(_ value: T?, _ message: String = "Unexpected nil value", file: StaticString = #file, line: UInt = #line) -> T {
+public func assertUnwrap<T>(
+    _ value: T?, _ message: String = "Unexpected nil value", file: StaticString = #file,
+    line: UInt = #line
+) -> T {
     guard let value = value else {
         XCTFail(message, file: file, line: line)
         preconditionFailure(message, file: file, line: line)
@@ -24,7 +27,9 @@ public func assertUnwrap<T>(_ value: T?, _ message: String = "Unexpected nil val
 }
 
 extension XCTestCase {
-    open func functionExpectation(_ id: String = "", caller: String = #function) -> XCTestExpectation {
+    open func functionExpectation(_ id: String = "", caller: String = #function)
+        -> XCTestExpectation
+    {
         return expectation(description: "\(caller)\(id)")
     }
 }

--- a/Proton/Tests/Renderer/MockRendererViewDelegate.swift
+++ b/Proton/Tests/Renderer/MockRendererViewDelegate.swift
@@ -7,15 +7,16 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 class MockRendererViewDelegate: RendererViewDelegate {
     var onDidTap: ((RendererView, CGPoint, NSRange?) -> Void)?
     var onDidChangeSelection: ((RendererView, NSRange) -> Void)?
 
-    func didTap(_ renderer: RendererView, didTapAtLocation location: CGPoint, characterRange: NSRange?) {
+    func didTap(
+        _ renderer: RendererView, didTapAtLocation location: CGPoint, characterRange: NSRange?
+    ) {
         onDidTap?(renderer, location, characterRange)
     }
 

--- a/Proton/Tests/Renderer/RendererSnapshotTests.swift
+++ b/Proton/Tests/Renderer/RendererSnapshotTests.swift
@@ -6,11 +6,10 @@
 //  Copyright © 2020 Rajdeep Kwatra. All rights reserved.
 //
 
-import Foundation
 import FBSnapshotTestCase
-import XCTest
-
+import Foundation
 import Proton
+import XCTest
 
 class RendererSnapshotTests: FBSnapshotTestCase {
     override func setUp() {
@@ -35,18 +34,19 @@ class RendererSnapshotTests: FBSnapshotTestCase {
         let renderer = viewController.renderer
         renderer.addBorder()
 
-        renderer.attributedText = NSAttributedString(string: """
-        Line 1   - abc
-        Line 2   - def
-        Line 3   - ghi
-        Line 4   - jkl
-        Line 5   - mno
-        Line 6   - pqr
-        Line 7   - stu
-        Line 8   - vwx
-        Line 9   - yza
-        Line 10  - bcd
-        """)
+        renderer.attributedText = NSAttributedString(
+            string: """
+                Line 1   - abc
+                Line 2   - def
+                Line 3   - ghi
+                Line 4   - jkl
+                Line 5   - mno
+                Line 6   - pqr
+                Line 7   - stu
+                Line 8   - vwx
+                Line 9   - yza
+                Line 10  - bcd
+                """)
 
         viewController.render()
 
@@ -87,7 +87,8 @@ class RendererSnapshotTests: FBSnapshotTestCase {
     func testGetsRectsForGivenRangeSpanningAcrossMultipleLines() {
         let viewController = RendererTestViewController()
         let renderer = viewController.renderer
-        renderer.attributedText = NSAttributedString(string: "This is some long string in the Renderer that wraps into the next line.")
+        renderer.attributedText = NSAttributedString(
+            string: "This is some long string in the Renderer that wraps into the next line.")
         viewController.render(size: CGSize(width: 300, height: 130))
         let rects = renderer.rects(for: NSRange(location: 25, length: 10))
         for rect in rects {

--- a/Proton/Tests/Renderer/RendererViewTests.swift
+++ b/Proton/Tests/Renderer/RendererViewTests.swift
@@ -17,7 +17,8 @@ class RendererViewTests: XCTestCase {
         let testExpectation = functionExpectation()
 
         let delegate = MockRendererViewDelegate()
-        let renderer = RendererView(frame: CGRect(origin: .zero, size: CGSize(width: 200, height: 50)))
+        let renderer = RendererView(
+            frame: CGRect(origin: .zero, size: CGSize(width: 200, height: 50)))
         renderer.attributedText = NSAttributedString(string: "This is a test string")
         renderer.delegate = delegate
         renderer.enableSelectionHandles = false
@@ -57,7 +58,8 @@ class RendererViewTests: XCTestCase {
         let testExpectation = functionExpectation()
 
         let delegate = MockRendererViewDelegate()
-        let renderer = RendererView(frame: CGRect(origin: .zero, size: CGSize(width: 200, height: 50)))
+        let renderer = RendererView(
+            frame: CGRect(origin: .zero, size: CGSize(width: 200, height: 50)))
         let attachment = Attachment(PanelView(), size: .fullWidth)
         let attrString = NSMutableAttributedString(string: "This is a test string")
         attrString.append(attachment.string)

--- a/Proton/Tests/RendererCommands/FindTextCommand.swift
+++ b/Proton/Tests/RendererCommands/FindTextCommand.swift
@@ -7,9 +7,8 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 class FindTextCommand: RendererCommand {
     var text = ""
@@ -22,9 +21,12 @@ class FindTextCommand: RendererCommand {
         for content in renderer.contents() {
             if case let .text(_, attributedString) = content.type,
                 let range = attributedString.string.range(of: text),
-                let enclosingRange = content.enclosingRange {
+                let enclosingRange = content.enclosingRange
+            {
                 let contentRange = attributedString.string.makeNSRange(from: range)
-                let scrollRange = NSRange(location: enclosingRange.location + contentRange.location, length: contentRange.length)
+                let scrollRange = NSRange(
+                    location: enclosingRange.location + contentRange.location,
+                    length: contentRange.length)
                 renderer.addAttribute(.backgroundColor, value: UIColor.cyan, at: scrollRange)
                 renderer.scrollRangeToVisible(scrollRange)
                 break

--- a/Proton/Tests/RendererCommands/RendererCommandExecutorTests.swift
+++ b/Proton/Tests/RendererCommands/RendererCommandExecutorTests.swift
@@ -7,9 +7,8 @@
 //
 
 import Foundation
-import XCTest
-
 import Proton
+import XCTest
 
 class RendererCommandExecutorTests: XCTestCase {
     func testExecutesCommandOnRenderer() {
@@ -21,13 +20,17 @@ class RendererCommandExecutorTests: XCTestCase {
         renderer.attributedText = NSAttributedString(string: "This is some text")
         renderer.selectedRange = selectedRange
 
-        let color = renderer.selectedText.attribute(.backgroundColor, at: 0, effectiveRange: nil) as? UIColor
+        let color = renderer.selectedText.attribute(.backgroundColor, at: 0, effectiveRange: nil)
+            as? UIColor
         XCTAssertNil(color)
 
         let command = HighlightTextCommand()
         commandExecutor.execute(command)
 
-        guard let highlightColor = renderer.selectedText.attribute(.backgroundColor, at: 0, effectiveRange: nil) as? UIColor else {
+        guard
+            let highlightColor = renderer.selectedText.attribute(
+                .backgroundColor, at: 0, effectiveRange: nil) as? UIColor
+        else {
             XCTFail("Failed to get background color information")
             return
         }

--- a/Proton/Tests/TextProcessors/Mocks/MockTextProcessor.swift
+++ b/Proton/Tests/TextProcessors/Mocks/MockTextProcessor.swift
@@ -19,7 +19,10 @@ class MockTextProcessor: TextProcessing {
 
     var processorCondition: (EditorView, NSRange) -> Bool
 
-    init(name: String = "MockTextProcessor", processorCondition: @escaping (EditorView, NSRange) -> Bool) {
+    init(
+        name: String = "MockTextProcessor",
+        processorCondition: @escaping (EditorView, NSRange) -> Bool
+    ) {
         self.name = name
         self.processorCondition = processorCondition
     }
@@ -28,7 +31,9 @@ class MockTextProcessor: TextProcessing {
         onWillProcess?(deletedText, insertedText)
     }
 
-    func process(editor: EditorView, range editedRange: NSRange, changeInLength delta: Int) -> Processed {
+    func process(editor: EditorView, range editedRange: NSRange, changeInLength delta: Int)
+        -> Processed
+    {
         guard processorCondition(editor, editedRange) else {
             return false
         }

--- a/Proton/Tests/TextProcessors/Processors/TestTextProcessor.swift
+++ b/Proton/Tests/TextProcessors/Processors/TestTextProcessor.swift
@@ -7,9 +7,8 @@
 //
 
 import Foundation
-import UIKit
-
 import Proton
+import UIKit
 
 class TestTextProcessor: TextProcessing {
     var name: String { return "TestTextProcessor" }
@@ -19,7 +18,9 @@ class TestTextProcessor: TextProcessing {
     var onProcess: ((EditorView, NSRange) -> Processed)?
     var onProcessInterrupted: ((EditorView, NSRange) -> Void)?
 
-    func process(editor: EditorView, range editedRange: NSRange, changeInLength delta: Int) -> Processed {
+    func process(editor: EditorView, range editedRange: NSRange, changeInLength delta: Int)
+        -> Processed
+    {
         return onProcess?(editor, editedRange) ?? false
     }
 

--- a/Proton/Tests/TextProcessors/TextProcessorTests.swift
+++ b/Proton/Tests/TextProcessors/TextProcessorTests.swift
@@ -53,7 +53,9 @@ class TextProcessorTests: XCTestCase {
         editor.replaceCharacters(in: .zero, with: testString)
         editor.registerProcessor(mockProcessor)
         let replacementRange = NSRange(location: 5, length: 4)
-        _ = richTextEditorContext.textView(editor.richTextView, shouldChangeTextIn: replacementRange, replacementText: replacementString)
+        _ = richTextEditorContext.textView(
+            editor.richTextView, shouldChangeTextIn: replacementRange,
+            replacementText: replacementString)
         editor.replaceCharacters(in: replacementRange, with: replacementString)
         waitForExpectations(timeout: 1.0)
     }
@@ -144,8 +146,10 @@ class TextProcessorTests: XCTestCase {
         let testAttribute = NSAttributedString.Key("testAttr")
 
         let processor: (EditorView, NSRange) -> Processed = { editor, _ in
-            let attrValue = editor.attributedText.attribute(testAttribute, at: 0, effectiveRange: nil) as? Int ?? 0
-            editor.addAttribute(testAttribute, value: attrValue + 1, at: editor.attributedText.fullRange)
+            let attrValue = editor.attributedText.attribute(
+                testAttribute, at: 0, effectiveRange: nil) as? Int ?? 0
+            editor.addAttribute(
+                testAttribute, value: attrValue + 1, at: editor.attributedText.fullRange)
             processorExpectation.fulfill()
             return true
         }
@@ -161,8 +165,10 @@ class TextProcessorTests: XCTestCase {
         editor.registerProcessor(processor2)
         editor.registerProcessor(processor3)
 
-        editor.replaceCharacters(in: editor.textEndRange, with: NSAttributedString(string: " string"))
-        let attrValue = editor.attributedText.attribute(testAttribute, at: 0, effectiveRange: nil) as? Int ?? 0
+        editor.replaceCharacters(
+            in: editor.textEndRange, with: NSAttributedString(string: " string"))
+        let attrValue = editor.attributedText.attribute(testAttribute, at: 0, effectiveRange: nil)
+            as? Int ?? 0
         XCTAssertEqual(attrValue, 3)
 
         waitForExpectations(timeout: 1.0)


### PR DESCRIPTION
Another possible code formatting option is [swift-format](https://github.com/apple/swift-format). Comparing to SwiftFormat #16 It is less opinionated in most cases.

Changed settings:
- indentation.spaces from 2 to 4
- tabWidth from 8 to 4

@rajdeep choose what tool do you like more or decline both PRs if you don't like it/don't want to have formatter in this repo.
