### PR TITLE
Mutable attachment

### DIFF
--- a/Proton/Sources/Attachment/Attachment.swift
+++ b/Proton/Sources/Attachment/Attachment.swift
@@ -96,8 +96,8 @@ open class Attachment: NSTextAttachment, BoundsObserving {
         return updatedString
     }
 
-    public var string: NSMutableAttributedString {
-        guard let isBlockAttachment = isBlockAttachment else { return NSMutableAttributedString(string: "<UNKNOWN CONTENT TYPE>") }
+    public var string: NSAttributedString {
+        guard let isBlockAttachment = isBlockAttachment else { return NSAttributedString(string: "<UNKNOWN CONTENT TYPE>") }
 //        let key = isBlockAttachment == true ? NSAttributedString.Key.contentType: NSAttributedString.Key.inlineContentType
         let string = NSMutableAttributedString(attachment: self)
         let value = name ?? EditorContent.Name.unknown
@@ -107,6 +107,14 @@ open class Attachment: NSTextAttachment, BoundsObserving {
             .isInlineAttachment: !isBlockAttachment
         ], range: string.fullRange)
         return string
+    }
+
+    public func fastMutableString() -> NSMutableAttributedString {
+        if let mutable = string as? NSMutableAttributedString {
+            return mutable
+        } else {
+            return string.mutableCopy() as! NSMutableAttributedString
+        }
     }
 
     final var frame: CGRect {


### PR DESCRIPTION
This PR is just for convenience (and a little bit of performance).

I'm using `attachment.string` in a big string building function and I'd like to save myself the hassle of converting the result to `NSMutableAtrrubutedString` every time. 

What do you think of this change?