### PR TITLE
Attachment.attachmentBounds

### DIFF
--- a/Proton/Sources/Attachment/Attachment.swift
+++ b/Proton/Sources/Attachment/Attachment.swift
@@ -255,14 +255,14 @@ open class Attachment: NSTextAttachment, BoundsObserving {
             size = contentView?.bounds.integral.size ?? view.bounds.integral.size
         }
 
-        if size == .zero,
+        if (size.width == 0 || size.height == 0),
             let fittingSize = contentView?.systemLayoutSizeFitting(textContainer.size) {
             size = fittingSize
         }
 
         switch self.size {
         case .matchContent:
-            size = contentView?.bounds.integral.size ?? view.bounds.integral.size
+            break
         case let .fixed(width):
             size = CGSize(width: min(size.width, width), height: size.height)
         case .fullWidth:


### PR DESCRIPTION
I probably need some assistance with this, but when trying to layout an Attachment with `size: .matchContent` we were getting weird results. This seemed to fix it.

Sometimes `contentView?.bounds.height` was `0` and we asked for it twice... and always returned `0`. Probably related to AutoLayout in a UITableViewCell.

Here, we ask for the size. If the size has a zero'd magnitude, we ask it for the `systemLayoutSizeFitting(...)` and we leave it at that. 

What do you think?