### PR TITLE
AutogrowingTextView allowsScrollingMagic

### DIFF
--- a/Proton/Sources/Core/RichTextView.swift
+++ b/Proton/Sources/Core/RichTextView.swift
@@ -85,14 +85,14 @@ class RichTextView: AutogrowingTextView {
         selectedTextRange = rangeToSet?.toTextRange(textInput: self) ?? oldRange
     }
 
-    init(frame: CGRect = .zero, context: RichTextViewContext) {
+    init(frame: CGRect = .zero, context: RichTextViewContext, allowsScrollingMagic: Bool = false) {
         let textContainer = TextContainer()
         let layoutManager = NSLayoutManager()
 
         layoutManager.addTextContainer(textContainer)
         storage.addLayoutManager(layoutManager)
 
-        super.init(frame: frame, textContainer: textContainer)
+        super.init(frame: frame, textContainer: textContainer, allowsScrollingMagic: allowsScrollingMagic)
         layoutManager.delegate = self
         textContainer.textView = self
         self.delegate = context

--- a/Proton/Sources/Core/RichTextView.swift
+++ b/Proton/Sources/Core/RichTextView.swift
@@ -85,14 +85,14 @@ class RichTextView: AutogrowingTextView {
         selectedTextRange = rangeToSet?.toTextRange(textInput: self) ?? oldRange
     }
 
-    init(frame: CGRect = .zero, context: RichTextViewContext, allowsScrollingMagic: Bool = false) {
+    init(frame: CGRect = .zero, context: RichTextViewContext, growsInfinitely: Bool) {
         let textContainer = TextContainer()
         let layoutManager = NSLayoutManager()
 
         layoutManager.addTextContainer(textContainer)
         storage.addLayoutManager(layoutManager)
 
-        super.init(frame: frame, textContainer: textContainer, allowsScrollingMagic: allowsScrollingMagic)
+        super.init(frame: frame, textContainer: textContainer, growsInfinitely: growsInfinitely)
         layoutManager.delegate = self
         textContainer.textView = self
         self.delegate = context

--- a/Proton/Sources/Editor/EditorView.swift
+++ b/Proton/Sources/Editor/EditorView.swift
@@ -101,9 +101,10 @@ open class EditorView: UIView {
     ///   - context: Optional context to be used. `EditorViewContext` is link between `EditorCommandExecutor` and the `EditorView`.
     ///   `EditorCommandExecutor` needs to have same context as the `EditorView` to execute a command on it. Unless you need to have
     ///    restriction around some commands to be restricted in execution on certain specific editors, the default value may be used.
-    public init(frame: CGRect = .zero, context: EditorViewContext = .shared, allowsScrollingMagic: Bool = true) {
+    ///   - growsInfinitely: `true` will optimise for full-height without scroll bars 
+    public init(frame: CGRect = .zero, context: EditorViewContext = .shared, growsInfinitely: Bool = false) {
         self.context = context.richTextViewContext
-        self.richTextView = RichTextView(frame: frame, context: self.context, allowsScrollingMagic: allowsScrollingMagic)
+        self.richTextView = RichTextView(frame: frame, context: self.context, growsInfinitely: growsInfinitely)
 
         super.init(frame: frame)
 
@@ -112,9 +113,9 @@ open class EditorView: UIView {
         setup()
     }
 
-    init(frame: CGRect, richTextViewContext: RichTextViewContext, allowsScrollingMagic: Bool = true) {
+    init(frame: CGRect, richTextViewContext: RichTextViewContext, growsInfinitely: Bool = false) {
         self.context = richTextViewContext
-        self.richTextView = RichTextView(frame: frame, context: context, allowsScrollingMagic: allowsScrollingMagic)
+        self.richTextView = RichTextView(frame: frame, context: context, growsInfinitely: growsInfinitely)
 
         super.init(frame: frame)
 

--- a/Proton/Sources/Editor/EditorView.swift
+++ b/Proton/Sources/Editor/EditorView.swift
@@ -101,9 +101,9 @@ open class EditorView: UIView {
     ///   - context: Optional context to be used. `EditorViewContext` is link between `EditorCommandExecutor` and the `EditorView`.
     ///   `EditorCommandExecutor` needs to have same context as the `EditorView` to execute a command on it. Unless you need to have
     ///    restriction around some commands to be restricted in execution on certain specific editors, the default value may be used.
-    public init(frame: CGRect = .zero, context: EditorViewContext = .shared) {
+    public init(frame: CGRect = .zero, context: EditorViewContext = .shared, allowsScrollingMagic: Bool = true) {
         self.context = context.richTextViewContext
-        self.richTextView = RichTextView(frame: frame, context: self.context)
+        self.richTextView = RichTextView(frame: frame, context: self.context, allowsScrollingMagic: allowsScrollingMagic)
 
         super.init(frame: frame)
 
@@ -112,9 +112,9 @@ open class EditorView: UIView {
         setup()
     }
 
-    init(frame: CGRect, richTextViewContext: RichTextViewContext) {
+    init(frame: CGRect, richTextViewContext: RichTextViewContext, allowsScrollingMagic: Bool = true) {
         self.context = richTextViewContext
-        self.richTextView = RichTextView(frame: frame, context: context)
+        self.richTextView = RichTextView(frame: frame, context: context, allowsScrollingMagic: allowsScrollingMagic)
 
         super.init(frame: frame)
 

--- a/Proton/Tests/Attachments/AttachmentSnapshotTests.swift
+++ b/Proton/Tests/Attachments/AttachmentSnapshotTests.swift
@@ -106,7 +106,7 @@ class AttachmentSnapshotTests: FBSnapshotTestCase {
     }
 
     private func makeDummyAttachment(text: String, size: AttachmentSize) -> Attachment {
-        let textView = RichTextAttachmentView(context: RichTextViewContext())
+        let textView = RichTextAttachmentView(context: RichTextViewContext(), growsInfinitely: true)
         textView.textContainerInset = .zero
         textView.layoutMargins = .zero
         textView.text = text

--- a/Proton/Tests/Base/AutogrowingTextViewSnapshotTests.swift
+++ b/Proton/Tests/Base/AutogrowingTextViewSnapshotTests.swift
@@ -22,7 +22,7 @@ class AutogrowingTextViewSnapshotTests: FBSnapshotTestCase {
 
     func testRendersTextViewBasedOnContent() {
         let viewController = SnapshotTestViewController()
-        let textView = AutogrowingTextView()
+        let textView = AutogrowingTextView(frame: .zero, textContainer: nil, allowsScrollingMagic: false)
         textView.translatesAutoresizingMaskIntoConstraints = false
         textView.text = "Sample with single line text"
         textView.addBorder()
@@ -41,7 +41,7 @@ class AutogrowingTextViewSnapshotTests: FBSnapshotTestCase {
 
     func testRendersMultilineTextViewBasedOnContent() {
         let viewController = SnapshotTestViewController()
-        let textView = AutogrowingTextView()
+        let textView = AutogrowingTextView(frame: .zero, textContainer: nil, allowsScrollingMagic: false)
         textView.translatesAutoresizingMaskIntoConstraints = false
         textView.text = "Sample with multiple lines of text. This text flows into the second line because of width constraint on textview"
         textView.addBorder()

--- a/Proton/Tests/Base/AutogrowingTextViewSnapshotTests.swift
+++ b/Proton/Tests/Base/AutogrowingTextViewSnapshotTests.swift
@@ -22,7 +22,7 @@ class AutogrowingTextViewSnapshotTests: FBSnapshotTestCase {
 
     func testRendersTextViewBasedOnContent() {
         let viewController = SnapshotTestViewController()
-        let textView = AutogrowingTextView(frame: .zero, textContainer: nil, allowsScrollingMagic: false)
+        let textView = AutogrowingTextView(frame: .zero, textContainer: nil, growsInfinitely: true)
         textView.translatesAutoresizingMaskIntoConstraints = false
         textView.text = "Sample with single line text"
         textView.addBorder()
@@ -41,7 +41,7 @@ class AutogrowingTextViewSnapshotTests: FBSnapshotTestCase {
 
     func testRendersMultilineTextViewBasedOnContent() {
         let viewController = SnapshotTestViewController()
-        let textView = AutogrowingTextView(frame: .zero, textContainer: nil, allowsScrollingMagic: false)
+        let textView = AutogrowingTextView(frame: .zero, textContainer: nil, growsInfinitely: true)
         textView.translatesAutoresizingMaskIntoConstraints = false
         textView.text = "Sample with multiple lines of text. This text flows into the second line because of width constraint on textview"
         textView.addBorder()

--- a/Proton/Tests/Base/AutogrowingTextViewTests.swift
+++ b/Proton/Tests/Base/AutogrowingTextViewTests.swift
@@ -15,7 +15,7 @@ class AutogrowingTextViewTests: XCTestCase {
     func testNotifiesDelegateOfBoundsChange() {
         let boundsObserver = MockBoundsObserver()
         let viewController = SnapshotTestViewController()
-        let textView = AutogrowingTextView()
+        let textView = AutogrowingTextView(frame: .zero, textContainer: nil, allowsScrollingMagic: false)
 
         let boundsChangeExpectation = expectation(description: #function)
         boundsChangeExpectation.expectedFulfillmentCount = 2

--- a/Proton/Tests/Base/AutogrowingTextViewTests.swift
+++ b/Proton/Tests/Base/AutogrowingTextViewTests.swift
@@ -15,7 +15,7 @@ class AutogrowingTextViewTests: XCTestCase {
     func testNotifiesDelegateOfBoundsChange() {
         let boundsObserver = MockBoundsObserver()
         let viewController = SnapshotTestViewController()
-        let textView = AutogrowingTextView(frame: .zero, textContainer: nil, allowsScrollingMagic: false)
+        let textView = AutogrowingTextView(frame: .zero, textContainer: nil, growsInfinitely: true)
 
         let boundsChangeExpectation = expectation(description: #function)
         boundsChangeExpectation.expectedFulfillmentCount = 2

--- a/Proton/Tests/Core/RichTextViewContextTests.swift
+++ b/Proton/Tests/Core/RichTextViewContextTests.swift
@@ -18,7 +18,7 @@ class RichTextViewContextTests: XCTestCase {
         let mockTextViewDelegate = MockRichTextViewDelegate()
 
         let context = RichTextEditorContext.default
-        let textView = RichTextView(context: RichTextViewContext())
+        let textView = RichTextView(context: RichTextViewContext(), growsInfinitely: true)
         textView.richTextViewDelegate = mockTextViewDelegate
         textView.text = "Sample text"
 
@@ -39,7 +39,7 @@ class RichTextViewContextTests: XCTestCase {
         let mockTextViewDelegate = MockRichTextViewDelegate()
 
         let context = RichTextEditorContext.default
-        let textView = RichTextView(context: RichTextViewContext())
+        let textView = RichTextView(context: RichTextViewContext(), growsInfinitely: true)
         textView.richTextViewDelegate = mockTextViewDelegate
         textView.text = "Sample text"
 
@@ -60,7 +60,7 @@ class RichTextViewContextTests: XCTestCase {
         let mockTextViewDelegate = MockRichTextViewDelegate()
 
         let context = RichTextEditorContext.default
-        let textView = RichTextView(context: context)
+        let textView = RichTextView(context: context, growsInfinitely: true)
         textView.richTextViewDelegate = mockTextViewDelegate
         textView.text = "Sample text"
 
@@ -81,7 +81,7 @@ class RichTextViewContextTests: XCTestCase {
         let mockTextViewDelegate = MockRichTextViewDelegate()
 
         let context = RichTextEditorContext.default
-        let textView = RichTextView(context: context)
+        let textView = RichTextView(context: context, growsInfinitely: true)
         textView.richTextViewDelegate = mockTextViewDelegate
         textView.text = "Sample text"
 
@@ -103,7 +103,7 @@ class RichTextViewContextTests: XCTestCase {
         let mockTextViewDelegate = MockRichTextViewDelegate()
 
         let context = RichTextEditorContext.default
-        let textView = RichTextView(context: context)
+        let textView = RichTextView(context: context, growsInfinitely: true)
         textView.richTextViewDelegate = mockTextViewDelegate
         textView.text = "Sample text"
 
@@ -125,7 +125,7 @@ class RichTextViewContextTests: XCTestCase {
         let mockTextViewDelegate = MockRichTextViewDelegate()
 
         let context = RichTextEditorContext.default
-        let textView = RichTextView(context: context)
+        let textView = RichTextView(context: context, growsInfinitely: true)
         textView.richTextViewDelegate = mockTextViewDelegate
         textView.text = "Sample text"
 
@@ -147,7 +147,7 @@ class RichTextViewContextTests: XCTestCase {
         let mockTextViewDelegate = MockRichTextViewDelegate()
 
         let context = RichTextEditorContext.default
-        let textView = RichTextView(context: context)
+        let textView = RichTextView(context: context, growsInfinitely: true)
         textView.richTextViewDelegate = mockTextViewDelegate
         textView.text = "Sample text"
 
@@ -173,7 +173,7 @@ class RichTextViewContextTests: XCTestCase {
         let key2 = NSAttributedString.Key("key2")
 
         let context = RichTextViewContext()
-        let textView = RichTextView(context: context)
+        let textView = RichTextView(context: context, growsInfinitely: true)
         textView.richTextViewDelegate = mockTextViewDelegate
         textView.text = "Sample text"
 

--- a/Proton/Tests/Core/RichTextViewSnapshotTests.swift
+++ b/Proton/Tests/Core/RichTextViewSnapshotTests.swift
@@ -22,7 +22,7 @@ class RichTextViewSnapshotTests: FBSnapshotTestCase {
 
     func testRendersTextInTextView() {
         let viewController = SnapshotTestViewController()
-        let textView = RichTextView(frame: .zero, context: RichTextViewContext())
+        let textView = RichTextView(frame: .zero, context: RichTextViewContext(), growsInfinitely: true)
         textView.translatesAutoresizingMaskIntoConstraints = false
         textView.text = "Sample with single line text"
         textView.addBorder()
@@ -41,7 +41,7 @@ class RichTextViewSnapshotTests: FBSnapshotTestCase {
 
     func testRendersMultilineTextViewBasedOnContent() {
         let viewController = SnapshotTestViewController()
-        let textView = RichTextView(frame: .zero, context: RichTextViewContext())
+        let textView = RichTextView(frame: .zero, context: RichTextViewContext(), growsInfinitely: true)
 
         let font = assertUnwrap(UIFont(name: "Papyrus", size: 12))
         let paragraphStyle = NSMutableParagraphStyle()

--- a/Proton/Tests/Core/RichTextViewTests.swift
+++ b/Proton/Tests/Core/RichTextViewTests.swift
@@ -17,7 +17,7 @@ class RichTextViewTests: XCTestCase {
         let key = NSAttributedString.Key("test_key")
         let value = "value"
         let viewController = SnapshotTestViewController()
-        let textView = RichTextView(frame: .zero, context: RichTextViewContext())
+        let textView = RichTextView(frame: .zero, context: RichTextViewContext(), growsInfinitely: true)
         textView.translatesAutoresizingMaskIntoConstraints = false
         let attributedText = NSMutableAttributedString(string: "This is a test string")
         attributedText.addAttributes([key: value], range: NSRange(location: 0, length: 4))
@@ -47,7 +47,7 @@ class RichTextViewTests: XCTestCase {
 
     func testResetsTypingAttributesOnDeleteBackwards() throws {
         let text = NSAttributedString(string: "a", attributes: [.foregroundColor: UIColor.blue])
-        let textView = RichTextView(context: RichTextViewContext())
+        let textView = RichTextView(context: RichTextViewContext(), growsInfinitely: true)
         textView.attributedText = text
         let preColor = try XCTUnwrap(textView.typingAttributes[.foregroundColor] as? UIColor)
         XCTAssertEqual(preColor, UIColor.blue)
@@ -59,7 +59,7 @@ class RichTextViewTests: XCTestCase {
 
     func testNotifiesDelegateOfSelectedRangeChanges() {
         let funcExpectation = functionExpectation()
-        let textView = RichTextView(context: RichTextViewContext())
+        let textView = RichTextView(context: RichTextViewContext(), growsInfinitely: true)
         let richTextViewDelegate = MockRichTextViewDelegate()
         textView.richTextViewDelegate = richTextViewDelegate
         textView.attributedText = NSAttributedString(string: "This is a test string")
@@ -75,7 +75,7 @@ class RichTextViewTests: XCTestCase {
     }
 
     func testSetsFocusBeforeForNonFocusableText() {
-        let textView = RichTextView(context: RichTextViewContext())
+        let textView = RichTextView(context: RichTextViewContext(), growsInfinitely: true)
         let text = NSMutableAttributedString(string: "0123")
         text.append(NSAttributedString(string: "4567", attributes: [.noFocus: true]))
         text.append(NSAttributedString(string: "890"))
@@ -87,7 +87,7 @@ class RichTextViewTests: XCTestCase {
     }
 
     func testSetsFocusAfterForNonFocusableText() {
-        let textView = RichTextView(context: RichTextViewContext())
+        let textView = RichTextView(context: RichTextViewContext(), growsInfinitely: true)
         let text = NSMutableAttributedString(string: "0123")
         text.append(NSAttributedString(string: "4567", attributes: [.noFocus: true]))
         text.append(NSAttributedString(string: "890"))
@@ -132,7 +132,7 @@ class RichTextViewTests: XCTestCase {
 
     private func assertKeyCommand(input: String, modifierFlags: UIKeyModifierFlags, assertions: @escaping ((EditorKey, UIKeyModifierFlags) -> Void), file: StaticString = #file, line: UInt = #line) {
         let funcExpectation = functionExpectation()
-        let textView = RichTextView(context: RichTextViewContext())
+        let textView = RichTextView(context: RichTextViewContext(), growsInfinitely: true)
         let richTextViewDelegate = MockRichTextViewDelegate()
         textView.richTextViewDelegate = richTextViewDelegate
 

--- a/Proton/Tests/Helpers/RichTextViewTestViewController.swift
+++ b/Proton/Tests/Helpers/RichTextViewTestViewController.swift
@@ -15,7 +15,7 @@ class RichTextViewTestViewController: SnapshotTestViewController {
     let textView: RichTextView
 
     init() {
-        textView = RichTextView(frame: .zero, context: RichTextViewContext())
+        textView = RichTextView(frame: .zero, context: RichTextViewContext(), growsInfinitely: true)
         super.init(nibName: nil, bundle: nil)
         setup()
     }


### PR DESCRIPTION
AutogrowingTextView has a built-in `maxHeight` feature which is really helpful. However, if we wanted a full height (especially for Renderer in a UITableViewCell) the performance is better if we never enable scrolling. Additionally, we're fighting with the `heightAnchor` constraint. If we just avoid adding unused constraints, and avoid extra computation in layoutSubviews, it worked more reliably for us.

I picked an intentionally funny name "allowsScrollingMagic" because your automatic scrolling stuff is really cool.

What do you think of this PR?