### PR TITLE
Fixing some memory leaks

### DIFF
--- a/Proton/Sources/Attachment/Attachment.swift
+++ b/Proton/Sources/Attachment/Attachment.swift
@@ -141,7 +141,7 @@ open class Attachment: NSTextAttachment, BoundsObserving {
     }
 
     /// `EditorView` containing this attachment
-    public private(set) var containerEditorView: EditorView?
+    public private(set) weak var containerEditorView: EditorView?
 
     /// Name of the content for the `EditorView`
     /// - SeeAlso:

--- a/Proton/Sources/Core/RichTextViewContext.swift
+++ b/Proton/Sources/Core/RichTextViewContext.swift
@@ -22,7 +22,7 @@ import Foundation
 import UIKit
 
 class RichTextViewContext: NSObject, UITextViewDelegate {
-    var activeTextView: RichTextView?
+    weak var activeTextView: RichTextView?
 
     func textView(_ textView: UITextView, shouldInteractWith textAttachment: NSTextAttachment, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
         return interaction != .presentActions


### PR DESCRIPTION
Found retain cycle in Attachment when it captures parent `EditorView`.
Also context kept reference to an editor instance.