### PR TITLE
guard sooner to avoid possible crash in _storage

### DIFF
--- a/Proton/Sources/Core/PRTextStorage.m
+++ b/Proton/Sources/Core/PRTextStorage.m
@@ -74,6 +74,14 @@
 
 - (void)replaceCharactersInRange:(NSRange)range withAttributedString:(NSAttributedString *)attrString {
     // TODO: Add undo behaviour
+    
+    // Handles the crash when nested list receives enter key in quick succession that unindents the list item.
+    // Check only required with Obj-C based TextStorage
+    if ((range.location + range.length) > _storage.length) {
+        // Out of bounds
+        return;
+    }
+    
     NSMutableAttributedString *replacementString = [attrString mutableCopy];
     // Fix any missing attribute that is in the location being replaced, but not in the text that
     // is coming in.
@@ -92,13 +100,9 @@
         [replacementString addAttributes:diff range:NSMakeRange(0, replacementString.length)];
     }
 
-    // Handles the crash when nested list receives enter key in quick succession that unindents the list item.
-    // Check only required with Obj-C based TextStorage
-    if (range.location + range.length <= _storage.length) {
-        NSAttributedString *deletedText = [_storage attributedSubstringFromRange:range];
-        [_textStorageDelegate textStorage:self willDeleteText:deletedText insertedText:replacementString range:range];
-        [super replaceCharactersInRange:range withAttributedString:replacementString];
-    }
+    NSAttributedString *deletedText = [_storage attributedSubstringFromRange:range];
+    [_textStorageDelegate textStorage:self willDeleteText:deletedText insertedText:replacementString range:range];
+    [super replaceCharactersInRange:range withAttributedString:replacementString];
 }
 
 - (void)replaceCharactersInRange:(NSRange)range withString:(NSString *)str {


### PR DESCRIPTION
We're seeing this crash in production.

![image](https://user-images.githubusercontent.com/5361118/99921561-4106e700-2d7f-11eb-91b0-c9c5dcdba21f.png)

I’m not sure where in this method it is calling `-[NSLayoutManager ensureLayoutForCharacterRange:]`. I think accessing this `_storage` might be out of bounds. We were doing a bounds check later (and dropping all this work if the check fails). This PR moves that check to the top.