### PR TITLE
Replace `attributedString(from:)` with `attribute(_:at:)` to avoid crash

### DIFF
--- a/Proton/Sources/Core/RichTextEditorContext.swift
+++ b/Proton/Sources/Core/RichTextEditorContext.swift
@@ -67,21 +67,20 @@ class RichTextEditorContext: RichTextViewContext {
                 return false
             }
 
-            guard range.endLocation <= textView.attributedText.length else { return false }
-
-            let substring = textView.attributedText.attributedSubstring(from: range)
-            guard substring.length > 0,
-                let attachment = substring.attribute(.attachment, at: 0, effectiveRange: nil) as? Attachment,
-                attachment.selectBeforeDelete else {
-                    return true
+            // User tapped backspace with nothing selected, selected or remove Attachment
+            if
+                range.length == 1, // Hit backspace with nothing selected
+                range.location <= textView.attributedText.length, // ... within bounds
+                let attachment = textView.attributedText.attribute(.attachment, at: range.location, effectiveRange: nil) as? Attachment,
+                attachment.selectBeforeDelete, // ...should be selected
+                !attachment.isSelected // ... but isn't.
+            {
+                attachment.isSelected = true // Select it
+                return false // don't delete anything
             }
 
-            if attachment.isSelected {
-                return true
-            } else {
-                attachment.isSelected = true
-                return false
-            }
+            // Else, handle backspace normally
+            return true
         }
 
         if text == "\n" {


### PR DESCRIPTION
We're seeing this crash in production:

![image](https://user-images.githubusercontent.com/5361118/99921570-4a904f00-2d7f-11eb-97c3-d02d8e75f9ae.png)

Making a substring out of bounds causes a crash. Obviously. But this also checks that it is in bounds. So I’m not sure why this could happen.

**My fix**: :taphead: “_Can’t have a substring crash if you don’t make a substring_”. We were creating a substring then getting the attachment at index 0, and discarding the substring. So I’m just getting the attachment at `range.location`.

---

I also re-wrote this function to be a bit more straight forward for my reading. Those changes are just opinion and not fixing a bug. It is the PR Author's opinion that this did not need to select the attachment unless the user is exactly behind the attachment and tapping delete once. 

If your text is `[attachment] foo`...
- If you select foo (without selecting the attachment), hitting backspace isn’t meant to select the attachment and do nothing. Instead, that should delete that text and move it to the end.
- If you select the whole thing, hitting backspace isn’t meant to select it either. I’m pretty sure selecting the range selects it, and that case wouldn’t be covered.

This behaviour of auto selecting if the user hits the backspace is only deserved when the user is directly behind without anything selected.