### PR TITLE
relayoutAttachments() - AutoLayout guard

### DIFF
--- a/Proton/Sources/Editor/EditorView.swift
+++ b/Proton/Sources/Editor/EditorView.swift
@@ -882,6 +882,17 @@ extension EditorView {
     }
 
     func relayoutAttachments(in range: NSRange? = nil) {
+        guard
+            richTextView.textContainer.size.height > 0,
+            richTextView.textContainer.size.height < CGFloat(Float.greatestFiniteMagnitude)
+        else {
+            /// AutoLayout may resize the TextContainer twice while calculating `intrinsicContentSize` (zero height & max height).
+            /// By this point, the LayoutManager has laid out the `NSAttachment`s as needed, which is enough for `intrinsicContentSize`.
+            /// There is no need to relayout Attachment's Views if the frame size or textContainer size isn't final.
+            /// By guarding here, we avoid unnecessary calculations & possible re-layouts of subviews & superviews.
+            return
+        }
+        
         let rangeToUse = range ?? richTextView.attributedText.fullRange
         richTextView.enumerateAttribute(.attachment, in: rangeToUse, options: .longestEffectiveRangeNotRequired) { (attach, range, _) in
             guard let attachment = attach as? Attachment else { return }

--- a/Proton/Tests/Editor/EditorViewTests.swift
+++ b/Proton/Tests/Editor/EditorViewTests.swift
@@ -194,6 +194,7 @@ class EditorViewTests: XCTestCase {
 
         editor.replaceCharacters(in: .zero, with: testString)
         editor.insertAttachment(in: editor.textEndRange, attachment: attachment)
+        editor.layoutIfNeeded() // renders attachment within zero-sized Editor
         editor.addAttributes(attributesToAdd, at: NSRange(location: 7, length: editor.contentLength - 7))
         waitForExpectations(timeout: 1.0)
     }
@@ -214,6 +215,7 @@ class EditorViewTests: XCTestCase {
 
         editor.replaceCharacters(in: .zero, with: testString)
         editor.insertAttachment(in: editor.textEndRange, attachment: attachment)
+        editor.layoutIfNeeded() // renders attachment within zero-sized Editor
         editor.removeAttribute(key, at: NSRange(location: 7, length: editor.contentLength - 7))
         waitForExpectations(timeout: 1.0)
     }


### PR DESCRIPTION
We're noticing a few stack overflows in `relayoutAttachments()`. I've raised another PR which implements a lock-style mechanism [here](https://github.com/rajdeep/proton/pull/80), however the tests aren't happy with that change. This PR attempts to no-op `relayoutAttachments(...)` by checking the TextContainer size. 

It was observed that `didFinishLayout` is called multiple times (far more than expected). In a debugging session where the Proton EditorView is used as a render-only view within a UITableView cell with a single `Attachment`, I presented the view controller once and printing the `richTextView.textContainer.size`.

```
relayout (0.0, 0.0)
relayout (309.0, 3.4028234663852886e+38)
relayout (309.0, 42.333333333333336)
relayout (309.0, 3.4028234663852886e+38)
relayout (309.0, 42.333333333333336)
relayout (0.0, 0.0)
relayout (348.0, 3.4028234663852886e+38)
relayout (0.0, 0.0)
relayout (348.0, 129.33333333333334)
relayout (0.0, 0.0)
relayout (348.0, 3.4028234663852886e+38)
relayout (0.0, 0.0)
relayout (348.0, 129.33333333333334) // << finally correct size
relayout (0.0, 0.0)
relayout (348.0, 129.33333333333334)
```

- 15 calls. 
- 6 when size is zero.
- 4 when size is `.greatestFiniteMagnitude`.

However with this guard in place, opening the same example view controller, here were the logs:

```
noop     (0.0, 0.0)
noop     (348.0, 3.4028234663852886e+38)
noop     (0.0, 0.0)
relayout (348.0, 42.333333333333336)
noop     (348.0, 3.4028234663852886e+38)
relayout (348.0, 42.333333333333336)
noop     (0.0, 0.0)
relayout (348.0, 42.333333333333336)
noop     (348.0, 3.4028234663852886e+38)
relayout (348.0, 42.333333333333336)
relayout (348.0, 129.33333333333334) // << finally correct size
relayout (348.0, 42.333333333333336)
relayout (348.0, 129.33333333333334)
```

The LayoutManager finished 13 times (8% less), yet we avoided layout 6 times (46% no-op'd).

Further data points using this example:

| Usage | `relayoutAttachment()` | No-op |
|---|---|---|
| Scroll UITableViewCell onto screen | 3 | 1 |
| Rotate to Landscape | 27 | 10 |
| Rotate back to Portrait | 50 | 15 |
