### PR TITLE
Which do I use? `attributedText` or `textStorage`?

### DIFF
--- a/Proton/Sources/EditorCommand/TextProcessors/ListTextProcessor.swift
+++ b/Proton/Sources/EditorCommand/TextProcessors/ListTextProcessor.swift
@@ -191,7 +191,7 @@ public class ListTextProcessor: TextProcessing {
             let originalParaStyle = originalParaStyle,
             editor.attributedText.attribute(.listItem, at: nextLine.range.location, longestEffectiveRange: &subListRange, in: NSRange(location: nextLine.range.location, length: editor.contentLength - nextLine.range.location)) != nil  else { return }
 
-        editor.attributedText.enumerateAttribute(.paragraphStyle, in: subListRange, options: []) { value, range, stop in
+        editor.richTextView.textStorage.enumerateAttribute(.paragraphStyle, in: subListRange, options: []) { value, range, stop in
             if let style = value as? NSParagraphStyle {
                 if style.firstLineHeadIndent >= originalParaStyle.firstLineHeadIndent + editor.listLineFormatting.indentation {
                     let mutableStyle = updatedParagraphStyle(paraStyle: style, listLineFormatting: editor.listLineFormatting, indentMode: indentMode)


### PR DESCRIPTION
Which do I use? `attributedText` or `textStorage`? Because they aren't the same!

> "_TextStorage is source of truth_" 

... yet this change fails a test.

| Expected | Failure |
|---|---|
| ![reference_1_DCDC6B2B-08DB-4542-9CFB-FE6BBE1B9F8A](https://user-images.githubusercontent.com/5361118/103754974-32d80600-5061-11eb-9d24-804097f95104.png) | ![failure_2_DCDC6B2B-08DB-4542-9CFB-FE6BBE1B9F8A](https://user-images.githubusercontent.com/5361118/103754988-379cba00-5061-11eb-97ed-530982ab5520.png) |

---

The reason I went down this path...

We have been seeing a lot of out of bounds crashes (I'm not able to reproduce them, sadly). We started adding bounds checks in various places. And then I remembered 

> "_Oh, we have our own `TextStorage` class. I should be able add the guards there once._" 

So I added the guards. Here's an example for `attributedSubstring(range:)`:

```objc
- (NSAttributedString *)attributedSubstringFromRange:(NSRange)range {
    if ([self boundsCheck:range]) {
        return [_storage attributedSubstringFromRange: range];
    } else {
        return [[NSAttributedString alloc] init];
    }
}
```

Tests were still passing. I set some break points and realised we weren't always calling those places. I noticed that some places we read or write from either `attributedText` or `textStorage`. Then I thought...

> "_Yay! This was probably the reason for the out of bounds. Now we have a single source of truth._"

So I ran the tests... and they failed. I closed my laptop and cried myself to sleep. I would very much like to understand which one I'm meant to use and when not to use.