### PR TITLE
Rename `RichTextView.storage` ivar

### DIFF
--- a/Proton/Sources/Core/PRTextStorage.h
+++ b/Proton/Sources/Core/PRTextStorage.h
@@ -37,7 +37,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) UIFont *defaultFont;
 @property (nonatomic, readonly) NSParagraphStyle *defaultParagraphStyle;
 @property (nonatomic, readonly) UIColor *defaultTextColor;
-@property (nonatomic, readonly) NSRange textEndRange;
 
 - (void)removeAttributes:(NSArray<NSAttributedStringKey> *)attrs range:(NSRange)range;
 - (void)insertAttachmentInRange:(NSRange)range attachment:(Attachment *)attachment;

--- a/Proton/Sources/Core/PRTextStorage.m
+++ b/Proton/Sources/Core/PRTextStorage.m
@@ -55,10 +55,6 @@
     }
 }
 
-- (NSRange)textEndRange {
-    return NSMakeRange(self.length, 0);
-}
-
 - (id)attribute:(NSAttributedStringKey)attrName atIndex:(NSUInteger)location effectiveRange:(NSRangePointer)range {
     return [_storage attribute:attrName atIndex:location effectiveRange:range];
 }

--- a/Proton/Sources/Core/RichTextEditorContext.swift
+++ b/Proton/Sources/Core/RichTextEditorContext.swift
@@ -175,6 +175,6 @@ class RichTextEditorContext: RichTextViewContext {
                 stop.pointee = true
             }
         }
-        return fontToApply ?? textView.richTextStorage.defaultFont
+        return fontToApply ?? textView.defaultFont
     }
 }

--- a/Proton/Sources/Core/RichTextView.swift
+++ b/Proton/Sources/Core/RichTextView.swift
@@ -24,7 +24,7 @@ import UIKit
 class RichTextView: AutogrowingTextView {
     
     /// Equivilant, strongly-typed alternative to `textStorage`
-    let richTextStorage = PRTextStorage()
+    private let richTextStorage = PRTextStorage()
     static let defaultListLineFormatting = LineFormatting(indentation: 25, spacingBefore: 0)
 
     weak var richTextViewDelegate: RichTextViewDelegate?
@@ -54,6 +54,7 @@ class RichTextView: AutogrowingTextView {
             .foregroundColor: defaultTextFormattingProvider?.textColor ?? richTextStorage.defaultTextColor
         ]
     }
+    var defaultFont: UIFont { richTextStorage.defaultFont }
     var defaultTextColor: UIColor { richTextStorage.defaultTextColor }
     var defaultBackgroundColor: UIColor {
         if #available(iOS 13.0, *) {

--- a/Proton/Sources/Core/RichTextView.swift
+++ b/Proton/Sources/Core/RichTextView.swift
@@ -22,15 +22,17 @@ import Foundation
 import UIKit
 
 class RichTextView: AutogrowingTextView {
-    private let storage = PRTextStorage()
+    
+    /// Equivilant, strongly-typed alternative to `textStorage`
+    let richTextStorage = PRTextStorage()
     static let defaultListLineFormatting = LineFormatting(indentation: 25, spacingBefore: 0)
 
     weak var richTextViewDelegate: RichTextViewDelegate?
     weak var richTextViewListDelegate: RichTextViewListDelegate?
 
     weak var defaultTextFormattingProvider: DefaultTextFormattingProviding? {
-        get { storage.defaultTextFormattingProvider }
-        set { storage.defaultTextFormattingProvider = newValue }
+        get { richTextStorage.defaultTextFormattingProvider }
+        set { richTextStorage.defaultTextFormattingProvider = newValue }
     }
 
     private let placeholderLabel = UILabel()
@@ -47,12 +49,12 @@ class RichTextView: AutogrowingTextView {
 
     var defaultTypingAttributes: RichTextAttributes {
         return [
-            .font: defaultTextFormattingProvider?.font ?? storage.defaultFont,
-            .paragraphStyle: defaultTextFormattingProvider?.paragraphStyle ?? storage.defaultParagraphStyle,
-            .foregroundColor: defaultTextFormattingProvider?.textColor ?? storage.defaultTextColor
+            .font: defaultTextFormattingProvider?.font ?? richTextStorage.defaultFont,
+            .paragraphStyle: defaultTextFormattingProvider?.paragraphStyle ?? richTextStorage.defaultParagraphStyle,
+            .foregroundColor: defaultTextFormattingProvider?.textColor ?? richTextStorage.defaultTextColor
         ]
     }
-    var defaultTextColor: UIColor { storage.defaultTextColor }
+    var defaultTextColor: UIColor { richTextStorage.defaultTextColor }
     var defaultBackgroundColor: UIColor {
         if #available(iOS 13.0, *) {
             return .systemBackground
@@ -162,14 +164,14 @@ class RichTextView: AutogrowingTextView {
         let layoutManager = LayoutManager()
 
         layoutManager.addTextContainer(textContainer)
-        storage.addLayoutManager(layoutManager)
+        richTextStorage.addLayoutManager(layoutManager)
 
         super.init(frame: frame, textContainer: textContainer)
         layoutManager.delegate = self
         layoutManager.layoutManagerDelegate = self
         textContainer.textView = self
         self.delegate = context
-        storage.textStorageDelegate = self
+        richTextStorage.textStorageDelegate = self
 
         self.backgroundColor = defaultBackgroundColor
         self.textColor = defaultTextColor
@@ -177,22 +179,18 @@ class RichTextView: AutogrowingTextView {
         setupPlaceholder()
     }
 
-    var richTextStorage: PRTextStorage {
-        return storage
-    }
-
     var contentLength: Int {
-        return storage.length
+        return textStorage.length
     }
 
     weak var textProcessor: TextProcessor? {
         didSet {
-            storage.delegate = textProcessor
+            richTextStorage.delegate = textProcessor
         }
     }
 
     var textEndRange: NSRange {
-        return storage.textEndRange
+        return NSRange(location: contentLength, length: 0)
     }
 
     var currentLineRange: NSRange? {
@@ -327,7 +325,7 @@ class RichTextView: AutogrowingTextView {
         // As mentioned above, in case of this getting called before layout is completed,
         // we need to account for the range that has been changed. storage.changeInLength provides
         // the change that might not have been laid already
-        return NSRange(location: range.location, length: range.length + storage.changeInLength)
+        return NSRange(location: range.location, length: range.length + textStorage.changeInLength)
     }
 
     func invalidateLayout(for range: NSRange) {
@@ -380,9 +378,9 @@ class RichTextView: AutogrowingTextView {
     }
 
     func edited(range: NSRange) {
-        richTextStorage.beginEditing()
-        richTextStorage.edited([.editedCharacters, .editedAttributes], range: range, changeInLength: 0)
-        richTextStorage.endEditing()
+        textStorage.beginEditing()
+        textStorage.edited([.editedCharacters, .editedAttributes], range: range, changeInLength: 0)
+        textStorage.endEditing()
     }
 
     func transformContents<T: EditorContentEncoding>(in range: NSRange? = nil, using transformer: T) -> [T.EncodedType] {
@@ -390,12 +388,12 @@ class RichTextView: AutogrowingTextView {
     }
 
     func replaceCharacters(in range: NSRange, with attrString: NSAttributedString) {
-        richTextStorage.replaceCharacters(in: range, with: attrString)
+        textStorage.replaceCharacters(in: range, with: attrString)
     }
 
     func replaceCharacters(in range: NSRange, with string: String) {
         // Delegate to function with attrString so that default attributes are automatically applied
-        richTextStorage.replaceCharacters(in: range, with: NSAttributedString(string: string))
+        textStorage.replaceCharacters(in: range, with: NSAttributedString(string: string))
     }
 
     private func updatePlaceholderVisibility() {
@@ -432,15 +430,15 @@ class RichTextView: AutogrowingTextView {
     }
 
     func addAttributes(_ attrs: [NSAttributedString.Key: Any], range: NSRange) {
-        storage.addAttributes(attrs, range: range)
+        textStorage.addAttributes(attrs, range: range)
     }
 
     func removeAttributes(_ attrs: [NSAttributedString.Key], range: NSRange) {
-        storage.removeAttributes(attrs, range: range)
+        richTextStorage.removeAttributes(attrs, range: range)
     }
 
     func enumerateAttribute(_ attrName: NSAttributedString.Key, in enumerationRange: NSRange, options opts: NSAttributedString.EnumerationOptions = [], using block: (Any?, NSRange, UnsafeMutablePointer<ObjCBool>) -> Void) {
-        storage.enumerateAttribute(attrName, in: enumerationRange, options: opts, using: block)
+        textStorage.enumerateAttribute(attrName, in: enumerationRange, options: opts, using: block)
     }
 
     func rangeOfCharacter(at point: CGPoint) -> NSRange? {


### PR DESCRIPTION
It is noted that the number of ivars in EditorView is confusing:

- `contentLength`
- `attributedText.contentLength`
- `richTextView.contentLength`
- `richTextView.attributedText.contentLength`
- `richTextView.textStorage.contentLength` Property from super class
- `richTextView.storage.contentLength` Typed version of textStorage, though this is private
- `richTextView.richTextStorage.contentLength` (internal computer property of storage)

... all look like the same thing.

This PR will:
- Remove existing `richTextStorage` computed property
- Rename `storage` to `richTextStorage` and make it internal
- Prefer calls to `textStorage` where possible, and `richTextStorage` if it uses a custom API. A number of other files reference `textStorage` which may not know about the custom subclass, so I prefer that we use the term `textStorage` in as many places as possible.