### PR TITLE
Introducing `NSAttributedString.substring(from:)`

### DIFF
--- a/Proton/Sources/Core/LayoutManager.swift
+++ b/Proton/Sources/Core/LayoutManager.swift
@@ -114,9 +114,9 @@ class LayoutManager: NSLayoutManager {
             var skipMarker = false
 
             if newLineRange.length > 0 {
-                let newLineString = textStorage.attributedSubstring(from: newLineRange)
-                isPreviousLineComplete = newLineString.string == "\n"
-                skipMarker = newLineString.attribute(.skipNextListMarker, at: 0, effectiveRange: nil) != nil
+                let newLineString = textStorage.substring(from: newLineRange)
+                isPreviousLineComplete = newLineString == "\n"
+                skipMarker = textStorage.attribute(.skipNextListMarker, at: newLineRange.location, effectiveRange: nil) != nil
             }
 
             let font = textStorage.attribute(.font, at: characterRange.location, effectiveRange: nil) as? UIFont ?? defaultFont
@@ -149,14 +149,15 @@ class LayoutManager: NSLayoutManager {
         var skipMarker = false
 
         if textStorage.length > 0 {
-            let lastChar = textStorage.attributedSubstring(from: NSRange(location: textStorage.length - 1, length: 1))
-            skipMarker = lastChar.string == "\n" && lastChar.attribute(.skipNextListMarker, at: 0, effectiveRange: nil) != nil
+            let range = NSRange(location: textStorage.length - 1, length: 1)
+            let lastChar = textStorage.substring(from: range)
+            skipMarker = lastChar == "\n" && textStorage.attribute(.skipNextListMarker, at: range.location, effectiveRange: nil) != nil
         }
 
         guard skipMarker == false,
             let lastRect = lastLayoutRect,
             textStorage.length > 1,
-            textStorage.attributedSubstring(from: NSRange(location: listRange.endLocation - 1, length: 1)).string == "\n",
+            textStorage.substring(from: NSRange(location: listRange.endLocation - 1, length: 1)) == "\n",
             let paraStyle = lastLayoutParaStyle  else { return }
 
         let level = Int(paraStyle.firstLineHeadIndent/listIndent)

--- a/Proton/Sources/Core/ListParser.swift
+++ b/Proton/Sources/Core/ListParser.swift
@@ -132,7 +132,7 @@ public struct ListParser {
         var startIndex = 0
 
         for newlineRange in newlineRanges {
-            let isNewlineSkipMarker = text.attributedSubstring(from: newlineRange).attribute(.skipNextListMarker, at: 0, effectiveRange: nil) != nil
+            let isNewlineSkipMarker = text.attribute(.skipNextListMarker, at: newlineRange.location, effectiveRange: nil) != nil
 
             if isNewlineSkipMarker {
                 continue

--- a/Proton/Sources/Core/PRTextStorage.m
+++ b/Proton/Sources/Core/PRTextStorage.m
@@ -147,12 +147,12 @@
     BOOL hasPrevSpacer = NO;
     if (range.length + range.location > 0) {
         NSRange subrange = NSMakeRange(range.location == 0 ? 0 : range.location - 1, 1);
-        hasPrevSpacer = [self attributedSubstringFromRange:subrange].string == spacer;
+        hasPrevSpacer = [self.string substringWithRange:subrange] == spacer;
     }
     BOOL hasNextSpacer = NO;
     if ((range.location + range.length + 1) <= self.length) {
         NSRange subrange = NSMakeRange(range.location, 1);
-        hasNextSpacer = [self attributedSubstringFromRange:subrange].string == spacer;
+        hasNextSpacer = [self.string substringWithRange:subrange] == spacer;
     }
 
     NSAttributedString *attachmentString = [attachment stringWithSpacersWithAppendPrev:!hasPrevSpacer appendNext:!hasNextSpacer];

--- a/Proton/Sources/Core/RichTextEditorContext.swift
+++ b/Proton/Sources/Core/RichTextEditorContext.swift
@@ -67,11 +67,11 @@ class RichTextEditorContext: RichTextViewContext {
                 return false
             }
 
-            guard range.endLocation <= textView.attributedText.length else { return false }
+            let attributedText: NSAttributedString = textView.attributedText // single allocation
+            guard range.endLocation <= attributedText.length else { return false }
 
-            let substring = textView.attributedText.attributedSubstring(from: range)
-            guard substring.length > 0,
-                let attachment = substring.attribute(.attachment, at: 0, effectiveRange: nil) as? Attachment,
+            guard range.length > 0,
+                let attachment = attributedText.attribute(.attachment, at: range.location, effectiveRange: nil) as? Attachment,
                 attachment.selectBeforeDelete else {
                     return true
             }

--- a/Proton/Sources/Core/RichTextView.swift
+++ b/Proton/Sources/Core/RichTextView.swift
@@ -353,12 +353,13 @@ class RichTextView: AutogrowingTextView {
         guard contentLength > 0 else { return }
         let proposedRange = NSRange(location: max(0, selectedRange.location - 1), length: 0)
 
+        let attributedText: NSAttributedString = self.attributedText // single allocation
         let attributeExists = (attributedText.attribute(.textBlock, at: proposedRange.location, effectiveRange: nil) as? Bool) == true
 
         guard attributeExists, let textRange = adjustedTextBlockRangeOnSelectionChange(oldRange: selectedRange, newRange: proposedRange) else {
 
             // if the character getting deleted is a list item spacer, do a double delete
-            let textToBeDeleted = attributedText.attributedSubstring(from: NSRange(location: proposedRange.location, length: 1)).string
+            let textToBeDeleted = attributedText.substring(from: NSRange(location: proposedRange.location, length: 1))
             if textToBeDeleted == ListTextProcessor.blankLineFiller {
                 super.deleteBackward()
             }

--- a/Proton/Sources/Editor/EditorView.swift
+++ b/Proton/Sources/Editor/EditorView.swift
@@ -231,7 +231,7 @@ open class EditorView: UIView {
     /// An attachment is only counted as a single character. Content length does not include
     /// length of content within the Attachment that is hosting another `EditorView`.
     public var contentLength: Int {
-        return attributedText.length
+        return richTextView.contentLength
     }
 
     /// Determines if the `EditorView` is editable or not.
@@ -882,7 +882,7 @@ extension EditorView {
     }
 
     func relayoutAttachments(in range: NSRange? = nil) {
-        let rangeToUse = range ?? richTextView.attributedText.fullRange
+        let rangeToUse = range ?? NSRange(location: 0, length: contentLength)
         richTextView.enumerateAttribute(.attachment, in: rangeToUse, options: .longestEffectiveRangeNotRequired) { (attach, range, _) in
             guard let attachment = attach as? Attachment else { return }
 

--- a/Proton/Sources/EditorCommand/Commands/ListCommand.swift
+++ b/Proton/Sources/EditorCommand/Commands/ListCommand.swift
@@ -77,7 +77,7 @@ public class ListCommand: EditorCommand {
             var length = max(currentLine.range.length, selectedRange.length + (selectedRange.location - currentLine.range.location))
             let range = NSRange(location: location, length: length)
             if editor.contentLength > range.endLocation,
-                editor.attributedText.attributedSubstring(from: NSRange(location: range.endLocation, length: 1)).string == "\n" {
+                editor.attributedText.substring(from: NSRange(location: range.endLocation, length: 1)) == "\n" {
                 length += 1
             }
             selectedRange = NSRange(location: location, length: length)

--- a/Proton/Sources/Helpers/NSAttributedString+Range.swift
+++ b/Proton/Sources/Helpers/NSAttributedString+Range.swift
@@ -126,4 +126,14 @@ public extension NSAttributedString {
         guard location < length else { return nil }
         return attribute(attributeKey, at: location, effectiveRange: nil) as? T
     }
+    
+    /// Alternative to `attributedSubstring(from:_).string`
+    /// Avoids allocating `NSAttributedString` and all the attributes for that range, only to ignore the range.
+    func substring(from range: NSRange) -> String {
+        guard range.upperBound <= length else {
+            assertionFailure("Substring is out of bounds")
+            return ""
+        }
+        return (string as NSString).substring(with: range)
+    }
 }

--- a/Proton/Sources/TextProcessors/TextProcessor.swift
+++ b/Proton/Sources/TextProcessors/TextProcessor.swift
@@ -57,7 +57,7 @@ class TextProcessor: NSObject, NSTextStorageDelegate {
         guard let editor = editor else { return }
         var executedProcessors = [TextProcessing]()
         var processed = false
-        let changedText = textStorage.attributedSubstring(from: editedRange).string
+        let changedText = textStorage.substring(from: editedRange)
 
         // This func is invoked even when selected range changes without change in text. Guard the code so that delegate call backs are
         // fired only when there is actual change in content


### PR DESCRIPTION
It's pretty common for us to do:

- Allocate an attributed substring
- Get an attribute at the 0th index
- Get the `NSString`

```swift
let attrText = editor.attributedText.attributedSubstring(from: range)
let attr1 = attrText.attribute(.fooAttr, at: 0, effectiveRange: nil) as? Foo
if attrText.string != "\n", attr1 != nil {
    print("yay")
}
```

This PR introduces a cheaper alternative for substrings that doesn't require allocating an `NSAttributedString` (and extracting all of the attributes, and then bridging to Swift types, only to blow it away).

```swift
let text = editor.attributedText.substring(from: range)
let attr1 = editor.attributedText.attribute(.fooAttr, at: range.location, effectiveRange: nil) as? Foo
if text != "\n", attr1 != nil {
    print("yay")
}
```

This will:
- Make a substring from the underlying NSString, without looking up the attributes at that range
- Get only one attribute at a given location