### PR TITLE
PRTextStorage now recognizes all applicable previous and next spacers

### DIFF
--- a/Proton/Sources/Attachment/Attachment.swift
+++ b/Proton/Sources/Attachment/Attachment.swift
@@ -97,6 +97,11 @@ open class Attachment: NSTextAttachment, BoundsObserving {
         let spacer = isBlockAttachment == true ? "\n" : " "
         return NSAttributedString(string: spacer)
     }
+    
+    @objc
+    var spacerCharacterSet: CharacterSet {
+        return isBlockAttachment == true ? .newlines : .whitespaces
+    }
 
     @objc
     func stringWithSpacers(appendPrev: Bool, appendNext: Bool) -> NSAttributedString {

--- a/Proton/Sources/Core/PRTextStorage.m
+++ b/Proton/Sources/Core/PRTextStorage.m
@@ -139,16 +139,16 @@
 }
 
 - (void)insertAttachmentInRange:(NSRange)range attachment:(Attachment *_Nonnull)attachment {
-    NSString *spacer = attachment.spacer.string;
+    NSCharacterSet *spacerCharacterSet = attachment.spacerCharacterSet;
     BOOL hasPrevSpacer = NO;
     if (range.length + range.location > 0) {
-        NSRange subrange = NSMakeRange(range.location == 0 ? 0 : range.location - 1, 1);
-        hasPrevSpacer = [self.string substringWithRange:subrange] == spacer;
+        NSUInteger characterIndex = range.location == 0 ? 0 : range.location - 1;
+        hasPrevSpacer = [spacerCharacterSet characterIsMember:[self.string characterAtIndex:characterIndex]];
     }
     BOOL hasNextSpacer = NO;
-    if ((range.location + range.length + 1) <= self.length) {
-        NSRange subrange = NSMakeRange(range.location, 1);
-        hasNextSpacer = [self.string substringWithRange:subrange] == spacer;
+    if (range.location + 1 < self.length) {
+        NSUInteger characterIndex = range.location + 1;
+        hasNextSpacer = [spacerCharacterSet characterIsMember:[self.string characterAtIndex:characterIndex]];
     }
 
     NSAttributedString *attachmentString = [attachment stringWithSpacersWithAppendPrev:!hasPrevSpacer appendNext:!hasNextSpacer];


### PR DESCRIPTION
This makes it so that the storage recognizes other types of newlines and whitespaces, not only "\n" and " ".