### PR TITLE
Add missing imports.

### DIFF
--- a/Proton/Sources/Swift/EditorCommand/Commands/StrikethroughCommand.swift
+++ b/Proton/Sources/Swift/EditorCommand/Commands/StrikethroughCommand.swift
@@ -19,6 +19,7 @@
 //
 
 import Foundation
+import UIKit
 
 public class StrikethroughCommand: AttributesToggleCommand {
     public init() {

--- a/Proton/Sources/Swift/EditorCommand/Commands/UnderlineCommand.swift
+++ b/Proton/Sources/Swift/EditorCommand/Commands/UnderlineCommand.swift
@@ -19,6 +19,7 @@
 //
 
 import Foundation
+import UIKit
 
 public class UnderlineCommand: AttributesToggleCommand {
     public init() {


### PR DESCRIPTION
This fixes compiler errors: `NSUnderlineStyle` could not be found because UIKit was not imported in that file.
The compiler error occurred when you included Proton as a dependency of another multi-platform Swift Package.