### PR TITLE
Retain font size when toggling font trait

### DIFF
--- a/Proton/Sources/Swift/Helpers/Text/FontExtensions.swift
+++ b/Proton/Sources/Swift/Helpers/Text/FontExtensions.swift
@@ -78,7 +78,7 @@ public extension UIFont {
             return self
         }
 
-        return UIFont(descriptor: updatedFontDescriptor, size: 0.0)
+        return UIFont(descriptor: updatedFontDescriptor, size: pointSize)
     }
 
     func removing(trait: UIFontDescriptor.SymbolicTraits) -> UIFont {
@@ -88,6 +88,6 @@ public extension UIFont {
             return self
         }
 
-        return UIFont(descriptor: updatedFontDescriptor, size: 0.0)
+        return UIFont(descriptor: updatedFontDescriptor, size: pointSize)
     }
 }


### PR DESCRIPTION
Whilst implementing the Proton text editor with a custom font/font size, we found that toggling traits such as bold or italics off would return the text to its original font but of the wrong size. 

On close inspection it would appear that the font was returning to its default size of 12 rather than the size we had set.

This small change retains the point size of the font after toggling these traits.