### PR TITLE
[emoji] fix the space rendering after apple emoji

### DIFF
--- a/Proton/Sources/Swift/Helpers/Text/FontExtensions.swift
+++ b/Proton/Sources/Swift/Helpers/Text/FontExtensions.swift
@@ -43,6 +43,7 @@ public extension UIFont {
     var isAppleEmoji: Bool {
         return fontName == ".AppleColorEmojiUI" // inserted from iOS Emoji keyboard or macOS Character Viewer
             || fontName == "LastResort" // interesting font available since Mac OS 8.5 to render unsupported emoji
+            || fontName == "AppleColorEmoji"
     }
 
     var textStyle: UIFont.TextStyle {


### PR DESCRIPTION
When we use a custom font - the apple emoji font name changed and the emoji fix stopped working. Include the correct font name for our case.