### PR TITLE
Fixed context.selectedEditor to only be set if editor is focused when…

### DIFF
--- a/Proton/Sources/Swift/Core/RichTextViewContext.swift
+++ b/Proton/Sources/Swift/Core/RichTextViewContext.swift
@@ -33,7 +33,12 @@ class RichTextViewContext: NSObject, UITextViewDelegate {
     func textViewDidChangeSelection(_ textView: UITextView) {
         guard textView.delegate === self else { return }
         if textView.selectedTextRange != nil {
-            selectedTextView = textView.asRichTextView
+            if (textView.isEditable && textView.isFirstResponder) ||
+                textView.isEditable == false {
+                selectedTextView = textView.asRichTextView
+            } else {
+                selectedTextView = nil
+            }
         } else {
             selectedTextView = nil
         }

--- a/Proton/Tests/Core/RichTextViewContextTests.swift
+++ b/Proton/Tests/Core/RichTextViewContextTests.swift
@@ -25,6 +25,25 @@ import XCTest
 
 class RichTextViewContextTests: XCTestCase {
 
+    var window: UIWindow!
+    var viewController: UIViewController!
+
+
+    override func setUp() {
+        super.setUp()
+        window = UIWindow(frame: UIScreen.main.bounds)
+        viewController = UIViewController()
+        window.rootViewController = viewController
+
+        window.makeKeyAndVisible()
+    }
+
+    override func tearDown() {
+        viewController = nil
+        window = nil
+        super.tearDown()
+    }
+
     func testInvokesSelectionChange() {
         let testExpectation = expectation(description: #function)
         let mockTextViewDelegate = MockRichTextViewDelegate()
@@ -297,12 +316,37 @@ class RichTextViewContextTests: XCTestCase {
         waitForExpectations(timeout: 1.0)
     }
 
-    func testSetsSelectedEditorOnTextRangeChange() {
+    func testSetsSelectedEditorOnTextRangeChangeWhenReadOnly() {
         let testExpectation = expectation(description: #function)
         let mockTextViewDelegate = MockRichTextViewDelegate()
 
         let context = RichTextEditorContext.default
         let textView = RichTextView(context: context)
+        textView.isEditable = false
+        textView.richTextViewDelegate = mockTextViewDelegate
+
+        textView.text = "Sample text"
+        textView.selectedRange = .zero
+
+        mockTextViewDelegate.onSelectionChanged = { _, _, _, _ in
+            XCTAssertEqual(context.selectedTextView, textView)
+            testExpectation.fulfill()
+        }
+
+        context.textViewDidChangeSelection(textView)
+
+        waitForExpectations(timeout: 1.0)
+    }
+
+    func testSetsSelectedEditorOnTextRangeChangeWhenIsFirstResponder() {
+        let testExpectation = expectation(description: #function)
+        let mockTextViewDelegate = MockRichTextViewDelegate()
+
+        let context = RichTextEditorContext.default
+        let textView = RichTextView(context: context)
+        viewController.view.addSubview(textView)
+
+        XCTAssertTrue(textView.becomeFirstResponder())
         textView.richTextViewDelegate = mockTextViewDelegate
 
         textView.text = "Sample text"


### PR DESCRIPTION
… editable